### PR TITLE
Fix builds in editable mode

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -162,6 +162,8 @@ def build(setup_kwargs: Dict[str, Any]) -> None:
                 source_dir="cpp/deps/chuffed",
                 install_prefix="skdecide/hub",
                 cmake_configure_options=[
+                           f"-DBISON_EXECUTABLE=false",
+                           f"-DFLEX_EXECUTABLE=false",
                            ]),
             CMakeExtension(
                 name="gecode",

--- a/builder.py
+++ b/builder.py
@@ -140,6 +140,14 @@ class ExtensionBuilder(build_ext):
         # Install the project
         subprocess.check_call(install_command)
 
+    def copy_extensions_to_source(self):
+        original_extensions = list(self.extensions)
+        self.extensions = [
+            ext for ext in self.extensions
+            if not isinstance(ext, CMakeExtension) or not ext.disable_editable
+        ]
+        super().copy_extensions_to_source()
+        self.extensions = original_extensions
 
 
 def build(setup_kwargs: Dict[str, Any]) -> None:
@@ -147,7 +155,7 @@ def build(setup_kwargs: Dict[str, Any]) -> None:
 
     cmake_modules = [
         CMakeExtension(
-            name="skdecide/hub/",
+            name="skdecide/hub/__skdecide_hub_cpp",
             source_dir="cpp",
             install_prefix="",
             cmake_configure_options=[
@@ -159,6 +167,7 @@ def build(setup_kwargs: Dict[str, Any]) -> None:
         cmake_modules.extend([
             CMakeExtension(
                 name="chuffed",
+                disable_editable=True,
                 source_dir="cpp/deps/chuffed",
                 install_prefix="skdecide/hub",
                 cmake_configure_options=[
@@ -167,11 +176,14 @@ def build(setup_kwargs: Dict[str, Any]) -> None:
                            ]),
             CMakeExtension(
                 name="gecode",
+                disable_editable=True,
                 source_dir="cpp/deps/gecode",
                 install_prefix="skdecide/hub",
                 cmake_configure_options=[
                            ]),
-            CMakeExtension(name="libminizinc",
+            CMakeExtension(
+                name="libminizinc",
+                disable_editable=True,
                 source_dir="cpp/deps/libminizinc",
                 install_prefix="skdecide/hub",
                 cmake_configure_options=[

--- a/skdecide/discrete_optimization/generic_tools/result_storage/resultcomparator.py
+++ b/skdecide/discrete_optimization/generic_tools/result_storage/resultcomparator.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from skdecide.discrete_optimization.generic_tools.result_storage import ResultStorage, result_storage_to_pareto_front
+from skdecide.discrete_optimization.generic_tools.result_storage.result_storage import ResultStorage, result_storage_to_pareto_front
 from typing import List
 from skdecide.discrete_optimization.generic_tools.do_problem import Problem
 


### PR DESCRIPTION
README instructions tell to compile scikit-decide by running

    poetry install --no-root --extras all
    poetry build

But as a developer this is frustrating because we have to wait for a long build time when testing changes in source code. We want instead to build scikit-decide in editable mode (like `pip install -e`) by running instead

    poetry install --extras all

This PR makes this possible.  