### PR TITLE
[Trivial] Make doc generation easier for a VuePress developper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,9 +252,5 @@ jobs:
         run: |
           pip install --pre --find-links ./wheels/ "scikit-decide[all]"
 
-      - name: Generate Python docs
-        run: |
-          (cd docs; python autodoc.py)
-
       - name: generate documentation
         run: yarn global add vuepress && yarn install && yarn docs:build && touch docs/.vuepress/dist/.nojekyll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,10 +301,6 @@ jobs:
         run: |
           pip install --pre --find-links ./wheels "scikit-decide[all]"
 
-      - name: Generate
-        run: |
-          (cd docs; python autodoc.py)
-
       - name: generate documentation
         run: yarn global add vuepress && yarn install && yarn docs:build && touch docs/.vuepress/dist/.nojekyll
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "docs:dev": "vuepress dev docs",
-    "docs:build": "vuepress build docs"
+    "docs:dev": "(cd docs && python autodoc.py) && vuepress dev docs",
+    "docs:build": "(cd docs && python autodoc.py) && vuepress build docs"
   },
   "devDependencies": {
     "vuepress": "^1.0.2"


### PR DESCRIPTION
A VuePress developper will use either `yarn run docs:dev` to test the documentation or `yarn run docs:build`to generate it. It seems natural to integrate the generation of the `_state.json`  file read by `docs/.vuepress/enhanceApp.js` into that process.