### PR TITLE
[trivial] Treat version numbers as strings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016, macos-10.15, ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
     defaults:
       run:
         shell: bash
@@ -116,7 +116,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -152,7 +152,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -192,7 +192,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -230,7 +230,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: ["3.7"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016, macos-10.15, ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
     defaults:
       run:
         shell: bash
@@ -116,7 +116,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -152,7 +152,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -192,7 +192,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8"]
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -290,7 +290,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.7"
 
       - name: Download artifacts
         uses: actions/download-artifact@v1.0.0


### PR DESCRIPTION
Without quotes, version number is considered as a float, which will cause trouble with Python 3.10.

See https://github.com/github/docs/issues/11019