### PR TITLE
Run pre-commit with python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
         run: sudo apt install -y clang-format-9
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
       - uses: pre-commit/action@v2.0.0
 
   build:


### PR DESCRIPTION
Build logs show that pre-commit does not run because pycln cannot be installed.
Github runners now run Python 3.10 by default, but pycln has not yet been ported
  https://github.com/hadialqattan/pycln/issues/78