### PR TITLE
Integration of new notebooks in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,24 @@ Make sure you are in the "scikit-decide" root directory and install documentatio
 yarn install
 ```
 
+#### 3. Define environment variables for binder links
 
-#### 3. Build the docs
+In order to define appropriate links for notebooks (github source + launching on binder), we need several environment variables:
+- AUTODOC_BINDER_ENV_GH_REPO_NAME: name of the github repository hosting the binder environment
+- AUTODOC_BINDER_ENV_GH_BRANCH: branch hosting the binder environment
+- AUTODOC_NOTEBOOKS_REPO_URL: url of the content repository for the notebooks 
+- AUTODOC_NOTEBOOKS_BRANCH: branch containing the notebooks
+
+For instance:
+```shell
+export AUTODOC_BINDER_ENV_GH_REPO_NAME="airbus/scikit-decide"
+export AUTODOC_BINDER_ENV_GH_BRANCH="binder"
+current_repo_url_withdotgit=$(git remote get-url origin)
+export AUTODOC_NOTEBOOKS_REPO_URL=${current_repo_url_withdotgit/.git/}
+export AUTODOC_NOTEBOOKS_BRANCH=$(git branch --show-current)
+```
+
+#### 4. Build the docs
 
 Make sure you are in the "scikit-decide" root directory and using the virtual environment where you installed scikit-decide. 
 If you used poetry, that means prepending python commands with `poetry run`.
@@ -239,7 +255,7 @@ Then generate doc with:
 poetry run python docs/autodoc.py
 ```
  
-#### 4. Access the documentation
+#### 5. Access the documentation
 
 Make sure you are in the "scikit-decide" root directory and start the local documentation server:
 
@@ -251,9 +267,13 @@ Open your web browser to access the documentation (by default on http://localhos
 
 ## Examples
 
-The examples can be found in the `/examples` folder, showing how to import or define a domain, and how to run or solve it. Most of the examples rely on scikit-decide Hub, an extensible catalog of domains/solvers.
+### Notebooks
 
-Some examples are automatically embedded as Python notebooks in the `Examples` section of the documentation.
+A curated list of notebooks recommended to start with scikit-decide can be found in `notebooks/` folder.
+
+### Python scripts
+
+More examples can be found in the `examples/` folder, showing how to import or define a domain, and how to run or solve it. Most of the examples rely on scikit-decide Hub, an extensible catalog of domains/solvers.
 
 ### Playground
 

--- a/docs/autodoc.py
+++ b/docs/autodoc.py
@@ -12,68 +12,15 @@ import re
 import sys
 from functools import lru_cache
 from glob import glob
+import urllib
+import logging
 
 import skdecide
 
+NOTEBOOKS_LIST_PLACEHOLDER = "[[notebooks-list]]"
+
+logger = logging.getLogger(__name__)
 refs = set()
-header_comment = '# %%\n'
-
-
-# https://github.com/kiwi0fruit/ipynb-py-convert/blob/master/ipynb_py_convert/__main__.py
-def py2nb(py_str, title=None):
-    cells = []
-    if title is not None:
-        # first cell = title
-        cell = {
-            'cell_type': 'markdown',
-            'metadata': {},
-            'source': [f'# {title}'],
-        }
-        cells.append(cell)
-
-    chunks = py_str.split(f'\n\n{header_comment}')[1:]
-    for chunk in chunks:
-        cell_type = 'code'
-        chunk = chunk.strip()
-        if chunk.startswith('"""'):
-            chunk = chunk.strip('"\n')
-            cell_type = 'markdown'
-        elif chunk.startswith("# %"):
-            # magic commands
-            chunk = chunk[2:]
-
-        cell = {
-            'cell_type': cell_type,
-            'metadata': {},
-            'source': chunk.splitlines(True),
-        }
-
-        if cell_type == 'code':
-            cell.update({'outputs': [], 'execution_count': None})
-
-        cells.append(cell)
-
-    notebook = {
-        'cells': cells,
-        'metadata': {
-            'anaconda-cloud': {},
-            'kernelspec': {
-                'display_name': 'Python 3',
-                'language': 'python',
-                'name': 'python3'},
-            'language_info': {
-                'codemirror_mode': {'name': 'ipython', 'version': 3},
-                'file_extension': '.py',
-                'mimetype': 'text/x-python',
-                'name': 'python',
-                'nbconvert_exporter': 'python',
-                'pygments_lexer': 'ipython3',
-                'version': '3.6.1'}},
-        'nbformat': 4,
-        'nbformat_minor': 1
-    }
-
-    return notebook
 
 
 # https://stackoverflow.com/questions/48879353/how-do-you-recursively-get-all-submodules-in-a-python-package
@@ -208,6 +155,54 @@ def write_signature(md, member):
 
 def is_implemented(func_code):
     return not func_code.strip().endswith('raise NotImplementedError')
+
+
+def get_binder_link(
+    binder_env_repo_name: str,
+    binder_env_branch: str,
+    notebooks_repo_url: str,
+    notebooks_branch: str,
+    notebook_relative_path: str,
+) -> str:
+    # binder hub url
+    jupyterhub = urllib.parse.urlsplit("https://mybinder.org")
+
+    # path to the binder env
+    binder_path = f"v2/gh/{binder_env_repo_name}/{binder_env_branch}"
+
+    # nbgitpuller query
+    notebooks_repo_basename = os.path.basename(notebooks_repo_url)
+    urlpath = f"tree/{notebooks_repo_basename}/{notebook_relative_path}"
+    next_url_params = urllib.parse.urlencode(
+        {
+            "repo": notebooks_repo_url,
+            "urlpath": urlpath,
+            "branch": notebooks_branch,
+        }
+    )
+    next_url = f"git-pull?{next_url_params}"
+    query = urllib.parse.urlencode({"urlpath": next_url})
+
+    # full link
+    link = urllib.parse.urlunsplit(
+        urllib.parse.SplitResult(
+            scheme=jupyterhub.scheme,
+            netloc=jupyterhub.netloc,
+            path=binder_path,
+            query=query,
+            fragment="",
+        )
+    )
+
+    return link
+
+
+def get_github_link(
+    notebooks_repo_url: str,
+    notebooks_branch: str,
+    notebook_relative_path: str,
+) -> str:
+    return f"{notebooks_repo_url}/blob/{notebooks_branch}/{notebook_relative_path}"
 
 
 if __name__ == '__main__':
@@ -468,35 +463,87 @@ if __name__ == '__main__':
     with open(f'{docdir}/.vuepress/_state.json', 'w') as f:
         json.dump(state, f)
 
-    # Convert selected examples to notebooks & write Examples page (guide/_examples.md)
-    examples = '# Examples\n\n'
+    # List existing notebooks and replace it in guide's README
+    notebooks_list_text = ""
 
-    selected_examples = []
-    for example in glob(f'{docdir}/../examples/*.py'):
-        docstr, name, code = py_parse(example)
-        if docstr.startswith('Example '):
-            selected_examples.append((docstr, name, code))
+    # repos + branches to use for binder environment and notebooks content.
+    creating_links = True
+    try:
+        binder_env_repo_name = os.environ["AUTODOC_BINDER_ENV_GH_REPO_NAME"]
+    except KeyError:
+        binder_env_repo_name = "airbus/scikit-decide"
+    try:
+        binder_env_branch = os.environ["AUTODOC_BINDER_ENV_GH_BRANCH"]
+    except KeyError:
+        binder_env_branch = "binder"
+    try:
+        notebooks_repo_url = os.environ["AUTODOC_NOTEBOOKS_REPO_URL"]
+        notebooks_branch = os.environ["AUTODOC_NOTEBOOKS_BRANCH"]
+    except KeyError:
+        # missing environment variables => no github and binder links creation
+        notebooks_repo_url = ""
+        notebooks_branch = ""
+        creating_links = False
+        logger.warning("Missing environment variables AUTODOC_NOTEBOOKS_REPO_URL "
+                       "or AUTODOC_NOTEBOOKS_BRANCH to create github and binder links for notebooks.")
 
-    os.makedirs(f'{docdir}/.vuepress/public/notebooks', exist_ok=True)
-    sorted_examples = sorted(selected_examples)
-    for docstr, name, code in sorted_examples:
-        title = docstr[docstr.index(":")+1:]
-        examples += f'## {title}\n\n'
-        examples += f'<el-link type="primary" icon="el-icon-bottom" :underline="false" style="margin: 10px" href="../notebooks/{name}.ipynb">Download Notebook</el-link>\n'
-        examples += f'<el-link type="warning" icon="el-icon-cloudy" :underline="false" style="margin: 10px" href="https://colab.research.google.com/github/airbus/scikit-decide/blob/gh-pages/notebooks/{name}.ipynb">Run in Google Colab</el-link>\n\n'
-        notebook = py2nb(code, title=title)
+    # loop on notebooks
+    rootdir = os.path.abspath(f"{docdir}/..")
+    notebook_files = sorted(glob(f"{rootdir}/notebooks/*.ipynb"))
+    for notebook_file in notebook_files:
+        # load notebook
+        with open(notebook_file, "rt") as f:
+            notebook = json.load(f)
 
-        # Render cells, except for first cell with title
-        for cell in notebook['cells'][1:]:
-            cell_type = cell['cell_type']
-            cell_source = ''.join(cell['source'])
-            if cell_type == 'markdown':
-                examples += f'{cell_source}\n\n'
-            elif cell_type == 'code':
-                examples += f'``` py\n{cell_source}\n```\n\n'
+        # find title + description: from first cell,  h1 title + remaining text.
+        # or title from filename else
+        title = ""
+        description_lines = []
+        cell = notebook["cells"][0]
+        if cell["cell_type"] == "markdown":
+            if cell["source"][0].startswith("# "):
+                title = cell["source"][0][2:].strip()
+                description_lines = cell["source"][1:]
+            else:
+                description_lines = cell["source"]
+        if not title:
+            title = os.path.splitext(os.path.basename(notebook_file))[0]
 
-        with open(f'{docdir}/.vuepress/public/notebooks/{name}.ipynb', 'w') as f:
-            json.dump(notebook, f, indent=2)
+        if creating_links:
+            # binder link
+            notebook_path_prefix_len = len(f"{rootdir}/")
+            notebook_relative_path = notebook_file[notebook_path_prefix_len:]
+            binder_link = get_binder_link(
+                binder_env_repo_name=binder_env_repo_name,
+                binder_env_branch=binder_env_branch,
+                notebooks_repo_url=notebooks_repo_url,
+                notebooks_branch=notebooks_branch,
+                notebook_relative_path=notebook_relative_path,
+            )
+            binder_badge = f"[![Binder](https://mybinder.org/badge_logo.svg)]({binder_link})"
 
-    with open(f'{docdir}/guide/_examples.md', 'w') as f:
-        f.write(examples)
+            # github link
+            github_link = get_github_link(
+                notebooks_repo_url=notebooks_repo_url,
+                notebooks_branch=notebooks_branch,
+                notebook_relative_path=notebook_relative_path,
+            )
+
+            # markdown item
+            notebooks_list_text += f"- [{title}]({github_link}) {binder_badge}\n"
+        else:
+            # markdown item
+            notebooks_list_text += f"- {title}\n"
+
+        # description
+        for line in description_lines:
+            notebooks_list_text += f"  > {line}"
+        notebooks_list_text += "\n\n"
+
+    with open(f'{docdir}/guide/README.md.template', 'rt') as f:
+        readme_template_text = f.read()
+
+    readme_text = readme_template_text.replace(NOTEBOOKS_LIST_PLACEHOLDER, notebooks_list_text)
+
+    with open(f'{docdir}/guide/README.md', 'wt') as f:
+        f.write(readme_text)

--- a/docs/guide/README.md.template
+++ b/docs/guide/README.md.template
@@ -152,13 +152,15 @@ In the example of the Maze solved with Lazy A*, the goal (in green) should be re
 
 ## Examples
 
-**Go to <router-link to="_examples">Examples</router-link> for a curated list of Python notebooks (recommended to start).**
+### Notebooks
 
-More examples can be found in the `/examples` folder, showing how to import or define a domain, and how to run or solve it. Most of the examples rely on scikit-decide Hub, an extensible catalog of domains/solvers.
+Here is a curated list of notebooks recommended to start with scikit-decide, available in the `notebooks/` folder of the repository:
 
-**Warning**: the examples whose filename starts with an underscore are currently being migrated to the new API and might not be working in the meantime (same goes for domains/solvers inside `skdecide/hub`).
+[[notebooks-list]]
 
-**Warning**: some content currently in the hub (especially the MasterMind domain and the POMCP/CGP solvers) will require permission from their original authors before entering the public hub when open sourced.
+### Python scripts
+
+More examples can be found in the `examples/` folder, showing how to import or define a domain, and how to run or solve it. Most of the examples rely on scikit-decide Hub, an extensible catalog of domains/solvers.
 
 ### Playground
 


### PR DESCRIPTION
The new notebooks available in "notebooks/" folder will replace the previous small notebooks generated from python scripts in "examples/" folder.

The autodoc.py script is used to:
- list the notebooks and sort them alphabetically
- extract from first cell (which should be a markdown cell)
  - a title (first line if starting with "# ")
  - a description (the other lines)
- generate links
  - to get the notebook from github
  - to launch the notebook with binder
- modify the "guide" page by inserting this list with titles, description, and links,
  in "examples" section (a template will now be used to generate the docs/guide/README.md)
  More precisely, docs/guide/README.md is generated from docs/guide/README.md.template
  where placeholder [[notebooks-list]] is replaced by this list of notebooks

In order to have working links, some environment variables are needed to specify
- repository and branch used to host the binder environment
  -> if not defined, autodoc.py falls back to airbus/scikit-decide:binder
- repository and branch used to fetch the notebooks contents
  -> if not defined, autodoc.py does not generate github+binder links
     and issues a warning

README.md is updated to:
- explain how to define properly the environment variables to build the
  doc
- mention the notebooks in examples section


To test this PR, you can build the documentation locally by typing from root directory:
```shell
export AUTODOC_BINDER_ENV_GH_REPO_NAME="airbus/scikit-decide"
export AUTODOC_BINDER_ENV_GH_BRANCH="binder"
export AUTODOC_NOTEBOOKS_REPO_URL="https://github.com/nhuet/scikit-decide"
export AUTODOC_NOTEBOOKS_BRANCH="nh/doc_notebooks_integration"
yarn install
poetry run python docs/autodoc.py
yarn docs:dev
```
provided you have already installed the library in developer mode with poetry as explained in README.md.

To generate the online doc, the environment variables "AUTODOC_NOTEBOOKS_REPO_URL" and "AUTODOC_NOTEBOOKS_BRANCH" will have to be properly defined by the workflow to correspond to the repository and branch from which it is triggered, and for which the doc is generated. This update of online doc generation should be done in another PR.