### PR TITLE
[trivial] Upload generated doc as artifact for testing/reviewing purpose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,3 +270,9 @@ jobs:
 
       - name: generate documentation
         run: yarn global add vuepress && yarn install && yarn docs:build && touch docs/.vuepress/dist/.nojekyll
+
+      - name: upload as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: doc
+          path: docs/.vuepress/dist


### PR DESCRIPTION
**Goal:** To be able to review changes on online doc without having to make actual releases.

**Principle:** Use the generated artifact to serve locally the static website that would be published on github pages by releases.

**Proposed reviewing process for online doc:**
- Download the artifact "doc.zip" generated by the triggered action "Build scikit-decide"
- Extract the website contained in the artifact in a dedicated directory and serve it locally:
```shell
mkdir testdoc
cd testdoc
unzip path/to/doc.zip -d scikit-decide
python -m http.server
```
- Go to http://localhost:8000/scikit-decide/ and review!