### PR TITLE
ci-cd: add env variables needed to generate binder links in online doc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,6 +246,30 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Set env variables for github+binder links in doc
+        run: |
+          # binder environment repo and branch
+          AUTODOC_BINDER_ENV_GH_REPO_NAME="airbus/scikit-decide"
+          AUTODOC_BINDER_ENV_GH_BRANCH="binder"
+          # notebooks source repo and branch depending if it is a commit push or a PR
+          if [[ $GITHUB_REF == refs/pull* ]];
+          then
+              AUTODOC_NOTEBOOKS_REPO_URL="${GITHUB_SERVER_URL}/${{ github.event.pull_request.head.repo.full_name }}"
+              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_HEAD_REF}
+          elif [[ $GITHUB_REF == refs/heads* ]];
+          then
+              AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/heads\//}
+          fi
+          # export in GITHUB_ENV for next steps
+          echo "AUTODOC_BINDER_ENV_GH_REPO_NAME=${AUTODOC_BINDER_ENV_GH_REPO_NAME}" >> $GITHUB_ENV
+          echo "AUTODOC_BINDER_ENV_GH_BRANCH=${AUTODOC_BINDER_ENV_GH_BRANCH}" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_REPO_URL=${AUTODOC_NOTEBOOKS_REPO_URL}" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_BRANCH=${AUTODOC_NOTEBOOKS_BRANCH}" >> $GITHUB_ENV
+          # check computed variables
+          echo "Binder env: ${AUTODOC_BINDER_ENV_GH_REPO_NAME}/${AUTODOC_BINDER_ENV_GH_BRANCH}"
+          echo "Notebooks source: ${AUTODOC_NOTEBOOKS_REPO_URL}/tree/${AUTODOC_NOTEBOOKS_BRANCH}"
+
       - uses: actions/checkout@v2
         with:
           submodules: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set env variables for github+binder links in doc
+        run: |
+          echo "AUTODOC_BINDER_ENV_GH_REPO_NAME=airbus/scikit-decide" >> $GITHUB_ENV
+          echo "AUTODOC_BINDER_ENV_GH_BRANCH=binder" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
         with:
           submodules: true


### PR DESCRIPTION
The build.yml and release.yml are modified to define the environment  variables needed by autodoc.py to generate the github and binder links for notebooks after PR #85.

- variables for binder env are "hard-coded" to point to airbus/scikit-decide:binder
- variables for notebooks content are defined thanks to github variables available in actions

The resulting doc with proper github/binder links can be checked
- for build.yml: following process proposed in PR #88 , once PR #85 and PR #88 are merged.
- for release.yml: already on my [personal version of online doc](https://nhuet.github.io/scikit-decide/guide/#examples) as I tagged on my fork as a fake release,  a branch which merged already this PR and PR #85. 
NB: only one notebook listed here as PR #65 and PR #66 have not yet been merged.
