### PR TITLE
[trivial] Prevent build.yml workflow to trigger on tags push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: 🔨 Build scikit-decide
 
 on:
   push:
+    branches:
+      - "*"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
As this trigger is already handled by release.yml for release tags.