### PR TITLE
Publishing documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,11 +300,12 @@ jobs:
 
       - name: Deploy documentation in root folder on GH pages 🚀
         if: github.ref == 'refs/heads/master'
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          ACCESS_TOKEN: ${{ secrets.gh_access_token }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs/.vuepress/dist # The folder the action should deploy.
-          TARGET_FOLDER: / # The folder the action should deploy to.
-          COMMIT_MESSAGE: publish documentation
-          CLEAN_EXCLUDE: ["version/*"] # The directories to exclude from the clean.
+          token: ${{ secrets.gh_access_token }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/.vuepress/dist # The folder the action should deploy.
+          target-folder: / # The folder the action should deploy to.
+          commit-message: publish documentation
+          clean-exclude: |
+            "version/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,7 @@ jobs:
         python-version: ["3.7"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Set env variables for github+binder links in doc
         run: |
@@ -296,3 +297,14 @@ jobs:
         with:
           name: doc
           path: docs/.vuepress/dist
+
+      - name: Deploy documentation in root folder on GH pages 🚀
+        if: github.ref == 'refs/heads/master'
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.gh_access_token }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: docs/.vuepress/dist # The folder the action should deploy.
+          TARGET_FOLDER: / # The folder the action should deploy to.
+          COMMIT_MESSAGE: publish documentation
+          CLEAN_EXCLUDE: ["version/*"] # The directories to exclude from the clean.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,8 @@ jobs:
   build-docs:
     needs: [deploy]
     runs-on: ubuntu-latest
+    env:
+      DOCS_VERSION_PATH: /
 
     steps:
       - name: Set env variables for github+binder links in doc
@@ -289,6 +291,11 @@ jobs:
           echo "AUTODOC_BINDER_ENV_GH_BRANCH=binder" >> $GITHUB_ENV
           echo "AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Update DOCS_VERSION_PATH
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+            echo DOCS_VERSION_PATH=/version/${GITHUB_REF/refs\/tags\/v}/ >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
         with:
@@ -317,7 +324,7 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.gh_access_token }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs/.vuepress/dist # The folder the action should deploy.
+          TARGET_FOLDER: ${{ env.DOCS_VERSION_PATH }} # The folder the action should deploy to.
           GIT_CONFIG_EMAIL: guillaume.alleon@gmail.com
           COMMIT_MESSAGE: publish documentation
-          CLEAN: true
-          SINGLE_COMMIT: true
+          CLEAN: false # Releasing a new version is about creating a new directory, so we don't want to clean up the root.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,12 +319,11 @@ jobs:
         run: yarn global add vuepress && yarn install && yarn docs:build && touch docs/.vuepress/dist/.nojekyll
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          ACCESS_TOKEN: ${{ secrets.gh_access_token }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs/.vuepress/dist # The folder the action should deploy.
-          TARGET_FOLDER: ${{ env.DOCS_VERSION_PATH }} # The folder the action should deploy to.
-          GIT_CONFIG_EMAIL: guillaume.alleon@gmail.com
-          COMMIT_MESSAGE: publish documentation
-          CLEAN: false # Releasing a new version is about creating a new directory, so we don't want to clean up the root.
+          tokem: ${{ secrets.gh_access_token }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/.vuepress/dist # The folder the action should deploy.
+          target-folder: ${{ env.DOCS_VERSION_PATH }} # The folder the action should deploy to.
+          commit-message: publish documentation
+          clean: false # Releasing a new version is about creating a new directory, so we don't want to clean up the root.


### PR DESCRIPTION
This PR is the sibling of #72. It does the following:
  - Push release documentation on GH pages under `version/x.y.z` where `x.y.z` is the release number
  - Push latest master documentation on GH pages (intermediate master documentations can be found as artefacts in their respective build workflows)
 