### PR TITLE
Use clang-format wheel for pre-commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
   lint-sources:
     runs-on: ubuntu-latest
     steps:
-      - name: Install clang-format
-        run: sudo apt install -y clang-format-9
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,13 +29,11 @@ repos:
         language_version: python3
         exclude: ^cpp/
 
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.0
     hooks:
       - id: clang-format
-        name: clang-format
-        description: Format files with ClangFormat
-        language: system
-        entry: clang-format -i --style=file # LLVM style stored in .clang-format
+        args: [-i, -style=file]
         files: ^cpp/src/.*\.[ch]{2}$
 
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
This way clang-format is fully managed by pre-commit and does not have to be manually installed.