### PR TITLE
Rewrite extender as a generator

### DIFF
--- a/skdecide/hub/solver/lazy_astar/lazy_astar.py
+++ b/skdecide/hub/solver/lazy_astar/lazy_astar.py
@@ -65,16 +65,14 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities):
         self._domain = domain_factory()
 
         def extender(node, label, explored):
-            neigh = [
-                (self._domain.get_next_state(node, a), a)
-                for a in self._domain.get_applicable_actions(node).get_elements()
-            ]
-            neigh_not_explored = [(n, a) for n, a in neigh if n not in explored]
-            cost_labels = [
-                (n, self._domain.get_transition_value(node, a, n).cost, {"action": a})
-                for n, a in neigh_not_explored
-            ]
-            return cost_labels
+            for a in self._domain.get_applicable_actions(node).get_elements():
+                n = self._domain.get_next_state(node, a)
+                if n not in explored:
+                    yield (
+                        n,
+                        self._domain.get_transition_value(node, a, n).cost,
+                        {"action": a},
+                    )
 
         push = heappush
         pop = heappop


### PR DESCRIPTION
List comprehensions are faster than for-loops, but extender() computes
3 comprehension lists.  Its return value is used only once, and can be
replaced by an iterable, extender() can be rewritten as a generator.
This avoids creation of temporary lists, while still being readable.