### PR TITLE
Integrate notebooks in online documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -34,6 +34,10 @@ module.exports = {
                 link: '/guide/'
             },
             {
+                text: 'Notebooks',
+                link: '/notebooks/'
+            },
+            {
                 text: 'Reference',
                 link: '/reference/'
             },

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -152,13 +152,13 @@ In the example of the Maze solved with Lazy A*, the goal (in green) should be re
 
 ## Examples
 
-**Go to <router-link to="_examples">Examples</router-link> for a curated list of Python notebooks (recommended to start).**
+### Notebooks
 
-More examples can be found in the `/examples` folder, showing how to import or define a domain, and how to run or solve it. Most of the examples rely on scikit-decide Hub, an extensible catalog of domains/solvers.
+Go to the dedicated <router-link to="codegen">Notebooks</router-link> page to see a curated list of notebooks recommended to start with scikit-decide.
 
-**Warning**: the examples whose filename starts with an underscore are currently being migrated to the new API and might not be working in the meantime (same goes for domains/solvers inside `skdecide/hub`).
+### Python scripts
 
-**Warning**: some content currently in the hub (especially the MasterMind domain and the POMCP/CGP solvers) will require permission from their original authors before entering the public hub when open sourced.
+More examples can be found in the `examples/` folder, showing how to import or define a domain, and how to run or solve it. Most of the examples rely on scikit-decide Hub, an extensible catalog of domains/solvers.
 
 ### Playground
 

--- a/docs/notebooks/README.md.template
+++ b/docs/notebooks/README.md.template
@@ -1,0 +1,7 @@
+# Notebooks
+
+We present here a curated list of notebooks recommended to start with scikit-decide, available in the `notebooks/` folder of the repository.
+
+[[toc]]
+
+[[notebooks-list]]


### PR DESCRIPTION
- Add a "notebooks" tab in upper left menu:
  - subsection for each notebooks found in "notebooks/" sorted alphabetically (toc to have a list at the top of the page)
  - extraction of title and description from 1st cell if it is a markdown cell
     - title: first line if beginning with "# "
     - description: other lines
  - links to github and binder generated (see below)
- Add a link to it inside "Examples" subsection of guide
- Remove previous Examples subpage (the previous generated notebooks will be added  in this new notebooks page)

To generate the binder and github links, the autodoc.py script uses
environment variables:

In order to define appropriate links for notebooks (github source + launching on binder), we need several environment variables:
- AUTODOC_BINDER_ENV_GH_REPO_NAME: name of the github repository hosting the binder environment (default: airbus/scikit-decide)
- AUTODOC_BINDER_ENV_GH_BRANCH: branch hosting the binder environment (default: binder)
- AUTODOC_NOTEBOOKS_REPO_URL: url of the content repository for the notebooks
- AUTODOC_NOTEBOOKS_BRANCH: branch containing the notebooks

For instance, one can build locally the doc by typing from root directory :
```shell
export AUTODOC_BINDER_ENV_GH_REPO_NAME="airbus/scikit-decide"
export AUTODOC_BINDER_ENV_GH_BRANCH="binder"
current_repo_url_withdotgit=$(git remote get-url origin)
export AUTODOC_NOTEBOOKS_REPO_URL=${current_repo_url_withdotgit/.git/}
export AUTODOC_NOTEBOOKS_BRANCH=$(git branch --show-current)
poetry run yarn docs:dev
```
provided you have already installed the library in developper mode with poetry.