### PR TITLE
Re-add dropdown menu for versioned docs

### DIFF
--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -17,6 +17,7 @@
         >{{ $siteTitle }}</span
       >
     </RouterLink>
+    <versions />
 
     <div
       class="links"


### PR DESCRIPTION
It had been erroneously removed by 7e30b12.
There is no reason to set its class to "can-hide".