### PR TITLE
Put install instructions in a separate tab in online doc

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -30,6 +30,10 @@ module.exports = {
                 link: '/'
             },
             {
+                text: 'Install',
+                link: '/install'
+            },
+            {
                 text: 'Guide',
                 link: '/guide/'
             },

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -10,6 +10,8 @@ It is meant for being a one-stop shop solution to formalize decision-making prob
 
 <img :src="$withBase('/architecture.png')" alt="Architecture">
 
+Please refer to our <router-link to="/install">installation instructions</router-link> for installing scikit-decide.
+
 ### As a domain developer
 
 ::: tip
@@ -22,57 +24,6 @@ Scikit-decide supports formalizing the problem one characteristic at a time with
 Scikit-decide provides a meaningful API to interact with domains at the expected level of information, as well as a catalog of domains/solvers to test/benchmark new algorithms.
 :::
 
-## Installation
-
-### 1. Make sure to have a Python 3.7+ environment
-
-The use of a virtual environment for scikit-decide is recommended, and you will need to ensure the environment use a Python version greater than 3.7.
-This can be achieved either by using [conda](https://docs.conda.io/en/latest/) or by using [pyenv](https://github.com/pyenv/pyenv) (or [pyenv-win](https://github.com/pyenv-win/pyenv-win) on windows)
-and [venv](https://docs.python.org/fr/3/library/venv.html) module.
-
-The following examples show how to create a virtual environment with Python version 3.8.11 with the mentioned methods.
-
-#### With conda (all platforms)
-
-```shell
-conda create -n skdecide python=3.8.11
-conda activate skdecide
-```
-
-#### With pyenv + venv (Linux/MacOS)
-
-```shell
-pyenv install 3.8.11
-pyenv shell 3.8.11
-python -m venv skdecide-venv
-source skdecide-venv
-```
-
-#### With pyenv-win + venv (Windows)
-
-```shell
-pyenv install 3.8.11
-pyenv shell 3.8.11
-python -m venv skdecide-venv
-skdecide-venv\Scripts\activate
-```
-
-### 2. Install scikit-decide library
-
-#### Full install [Recommended]
-
-Install scikit-decide library from PyPI with all dependencies required by domains/solvers in the hub (scikit-decide catalog).
-```shell
-pip install -U pip
-pip install -U scikit-decide[all]
-```
-
-#### Minimal install
-Alternatively you can choose to only install the core library, which is enough if you intend to create your own domain and solver.
-```shell
-pip install -U pip
-pip install -U scikit-decide
-```
 ## Getting started
 
 Domain characteristics are one of the key concepts in scikit-decide: they are combined on the one hand to define domains, on the other hand to specify the envelope of domains a solver can tackle.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,51 @@
+# Installation
+
+## 1. Make sure to have a Python 3.7+ environment
+
+The use of a virtual environment for scikit-decide is recommended, and you will need to ensure the environment use a Python version greater than 3.7.
+This can be achieved either by using [conda](https://docs.conda.io/en/latest/) or by using [pyenv](https://github.com/pyenv/pyenv) (or [pyenv-win](https://github.com/pyenv-win/pyenv-win) on windows)
+and [venv](https://docs.python.org/fr/3/library/venv.html) module.
+
+The following examples show how to create a virtual environment with Python version 3.8.11 with the mentioned methods.
+
+### With conda (all platforms)
+
+```shell
+conda create -n skdecide python=3.8.11
+conda activate skdecide
+```
+
+### With pyenv + venv (Linux/MacOS)
+
+```shell
+pyenv install 3.8.11
+pyenv shell 3.8.11
+python -m venv skdecide-venv
+source skdecide-venv
+```
+
+### With pyenv-win + venv (Windows)
+
+```shell
+pyenv install 3.8.11
+pyenv shell 3.8.11
+python -m venv skdecide-venv
+skdecide-venv\Scripts\activate
+```
+
+## 2. Install scikit-decide library
+
+### Full install [Recommended]
+
+Install scikit-decide library from PyPI with all dependencies required by domains/solvers in the hub (scikit-decide catalog).
+```shell
+pip install -U pip
+pip install -U scikit-decide[all]
+```
+
+### Minimal install
+Alternatively you can choose to only install the core library, which is enough if you intend to create your own domain and solver.
+```shell
+pip install -U pip
+pip install -U scikit-decide
+```


### PR DESCRIPTION
The goal is to separate install instructions to
- give easy access to them
- lighten "guide" page