### PR TITLE
Add a quickstart notebook made of previous small autogenerated notebooks

### DIFF
--- a/notebooks/01_quickstart.ipynb
+++ b/notebooks/01_quickstart.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "484323a5",
+   "metadata": {},
+   "source": [
+    "# Getting started\n",
+    "\n",
+    "The purpose of this notebook is to show very quickly the main features of scikit-decide. The next notebooks are going more into details about specific problems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "781d8fbd",
+   "metadata": {},
+   "source": [
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Run-a-Gym-environment\" data-toc-modified-id=\"Run-a-Gym-environment-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Run a Gym environment</a></span></li><li><span><a href=\"#Solve-a-Gym-environment-with-Reinforcement-Learning\" data-toc-modified-id=\"Solve-a-Gym-environment-with-Reinforcement-Learning-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Solve a Gym environment with Reinforcement Learning</a></span></li><li><span><a href=\"#Solve-a-Gym-environment-with-Cartesian-Genetic-Programming\" data-toc-modified-id=\"Solve-a-Gym-environment-with-Cartesian-Genetic-Programming-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>Solve a Gym environment with Cartesian Genetic Programming</a></span></li></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "000f84ac",
+   "metadata": {},
+   "source": [
+    "##  Run a Gym environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c0c6977",
+   "metadata": {},
+   "source": [
+    "Import modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecc1a401",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gym\n",
+    "\n",
+    "from skdecide.hub.domain.gym import GymDomain\n",
+    "from skdecide.utils import rollout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9dca38c",
+   "metadata": {},
+   "source": [
+    "Select a [Gym environment](https://gym.openai.com/envs) and run 5 episodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5954c0a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENV_NAME = \"CartPole-v1\"  # or any other installed environment ('MsPacman-v4'...)\n",
+    "\n",
+    "gym_domain = GymDomain(gym.make(ENV_NAME))\n",
+    "rollout(\n",
+    "    gym_domain, num_episodes=5, max_steps=1000, max_framerate=30, outcome_formatter=None\n",
+    ")\n",
+    "gym_domain.close()  # optional but recommended to avoid Gym errors at the end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6623cd9",
+   "metadata": {},
+   "source": [
+    "##  Solve a Gym environment with Reinforcement Learning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e4fc0da",
+   "metadata": {},
+   "source": [
+    "Import modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa2fcec1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gym\n",
+    "from stable_baselines3 import PPO\n",
+    "\n",
+    "from skdecide.hub.domain.gym import GymDomain\n",
+    "from skdecide.hub.solver.stable_baselines import StableBaseline\n",
+    "from skdecide.utils import rollout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "152a0ac5",
+   "metadata": {},
+   "source": [
+    "Select a [Gym environment](https://gym.openai.com/envs) and solve it with a [Stable Baselines](https://stable-baselines3.readthedocs.io/en/master/index.html) solver wrapped in scikit-decide.\n",
+    "The solution is then saved (for later reuse) and assessed in rollout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aca77c66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENV_NAME = \"CartPole-v1\"\n",
+    "\n",
+    "domain_factory = lambda: GymDomain(gym.make(ENV_NAME))\n",
+    "domain = domain_factory()\n",
+    "if StableBaseline.check_domain(domain):\n",
+    "    solver_factory = lambda: StableBaseline(\n",
+    "        PPO, \"MlpPolicy\", learn_config={\"total_timesteps\": 30000}, verbose=1\n",
+    "    )\n",
+    "    with solver_factory() as solver:\n",
+    "        GymDomain.solve_with(solver, domain_factory)\n",
+    "        solver.save(\"TEMP_Baselines\")\n",
+    "        rollout(\n",
+    "            domain,\n",
+    "            solver,\n",
+    "            num_episodes=1,\n",
+    "            max_steps=1000,\n",
+    "            max_framerate=30,\n",
+    "            outcome_formatter=None,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc26df14",
+   "metadata": {},
+   "source": [
+    "Restore saved solution and re-run rollout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79d9fd6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with solver_factory() as solver:\n",
+    "    GymDomain.solve_with(solver, domain_factory, load_path=\"TEMP_Baselines\")\n",
+    "    rollout(\n",
+    "        domain,\n",
+    "        solver,\n",
+    "        num_episodes=1,\n",
+    "        max_steps=1000,\n",
+    "        max_framerate=30,\n",
+    "        outcome_formatter=None,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a16401b6",
+   "metadata": {},
+   "source": [
+    "##  Solve a Gym environment with Cartesian Genetic Programming"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a65e661f",
+   "metadata": {},
+   "source": [
+    "Import modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8959f6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gym\n",
+    "\n",
+    "from skdecide.hub.domain.gym import GymDomain\n",
+    "from skdecide.hub.solver.cgp import CGP  # Cartesian Genetic Programming\n",
+    "from skdecide.utils import rollout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bee43646",
+   "metadata": {},
+   "source": [
+    "Select a [Gym environment](https://gym.openai.com/envs) and solve it with Cartesian Genetic Programming in scikit-decide.\n",
+    "The solution is then assessed in rollout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90faccde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENV_NAME = \"MountainCarContinuous-v0\"\n",
+    "\n",
+    "domain_factory = lambda: GymDomain(gym.make(ENV_NAME))\n",
+    "domain = domain_factory()\n",
+    "if CGP.check_domain(domain):\n",
+    "    solver_factory = lambda: CGP(\"TEMP_CGP\", n_it=25)\n",
+    "    with solver_factory() as solver:\n",
+    "        GymDomain.solve_with(solver, domain_factory)\n",
+    "        rollout(\n",
+    "            domain,\n",
+    "            solver,\n",
+    "            num_episodes=5,\n",
+    "            max_steps=1000,\n",
+    "            max_framerate=30,\n",
+    "            outcome_formatter=None,\n",
+    "        )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "512px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
As discussed, I added a first notebook that gather the previous ones that were generated from some of the python scripts in examples/ folder. I omitted the one about the maze which seems to be just a lighter version of the maze tutorial already existing.

Now that I have done it, i am not really convinced because:

- I find it not so easy to understand from a newbie point of view.
- That makes duplicates with existing notebooks. All sections are more or less already sections of the gym tutorial.
- As it is, the notebook is not working on binder because of the way gym displays its environments. We can
  -  either create our own rollout as in gym tutorial => but this is will complexify the notebook and miss the purpose of quickness
  - or embed the environment in a monitor wrapper to generate movies

So to make it understandable and working on binder, some extra stuff should be added, and it seems to me that doing so it will looks very much like the existing gym tutorial.