### PR TITLE
Add benchmarking tutorial

### DIFF
--- a/notebooks/14_benchmarking_tuto.ipynb
+++ b/notebooks/14_benchmarking_tuto.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Benchmarking scikit-decide solvers\n",
+    "\n",
+    "This notebook demonstrates how to run and compare scikit-decide solvers compatible with a given domain. \n",
+    "\n",
+    "This benchmark is supported by [Ray Tune](https://docs.ray.io/en/latest/tune/index.html), a scalable Python library for experiment execution and hyperparameter tuning (incl. running experiments in parallel and logging results to Tensorboard). \n",
+    "\n",
+    "Benchmarking is important since the most efficient solvers might greatly vary depending on the domain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create or load a domain\n",
+    "\n",
+    "As an example, we will choose the Maze domain available in scikit-decide:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skdecide import utils\n",
+    "\n",
+    "MyDomain = utils.load_registered_domain(\"Maze\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Select solvers to benchmark\n",
+    "\n",
+    "We start by automatically detecting compatible solvers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compatible_solvers = utils.match_solvers(MyDomain())\n",
+    "print(len(compatible_solvers), \"compatible solvers:\", compatible_solvers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Optionally filter out some of these solvers: here we iteratively removed the ones running for too long in the cells below (thus blocking CPUs for other trials)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "benchmark_solvers = [\n",
+    "    solver\n",
+    "    for solver in compatible_solvers\n",
+    "    if solver.__name__ not in [\"AOstar\", \"ILAOstar\", \"MCTS\", \"POMCP\", \"UCT\"]\n",
+    "]\n",
+    "print(len(benchmark_solvers), \"solvers to benchmark:\", benchmark_solvers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define and run benchmark\n",
+    "\n",
+    "First, customize the objective function to optimize (this will serve to rank solver solutions). Here we choose *mean episode reward* to compare solvers, but we could also consider *reached goal ratio* or a mix of both...\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# note: most of this function's content could actually be done in 1 line with scikit-decide rollout utility (but we will need to upgrade it slightly for that)\n",
+    "def mean_episode_reward(solution, num_episodes=10, max_episode_steps=1000):\n",
+    "    domain = MyDomain()\n",
+    "    reward_sum = 0.0\n",
+    "    for _ in range(num_episodes):\n",
+    "        solution.reset()\n",
+    "        observation = domain.reset()\n",
+    "        episode_reward = 0.0\n",
+    "        step = 1\n",
+    "        while max_episode_steps is None or step <= max_episode_steps:\n",
+    "            action = solution.sample_action(observation)\n",
+    "            outcome = domain.step(action)\n",
+    "            observation = outcome.observation\n",
+    "            episode_reward += outcome.value.reward\n",
+    "            if outcome.termination:\n",
+    "                break\n",
+    "            step += 1\n",
+    "        reward_sum += episode_reward\n",
+    "    return reward_sum / num_episodes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define the training function for each benchmark trial (this is fairly generic and should not change much from one benchmark to another):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from inspect import signature\n",
+    "\n",
+    "from ray import tune\n",
+    "\n",
+    "\n",
+    "def training_function(config):\n",
+    "    # Get trial hyperparameters\n",
+    "    Solver = config[\"solver\"]\n",
+    "    solver_args = config.get(\"solver_args\", {}).get(Solver.__name__, {})\n",
+    "    if (\n",
+    "        \"domain_factory\" in signature(Solver.__init__).parameters\n",
+    "    ):  # note: this shouldn't be necessary (but currently required by some solvers until we solve the issue)\n",
+    "        solver_args[\"domain_factory\"] = MyDomain\n",
+    "    # Solve\n",
+    "    with Solver(**solver_args) as s:\n",
+    "        solution = MyDomain.solve_with(s)\n",
+    "        score = mean_episode_reward(solution)\n",
+    "    # Feed the score back to Tune\n",
+    "    tune.report(mean_episode_reward=score)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now it is time to run the benchmark. \n",
+    "\n",
+    "Some remarks: \n",
+    "- By default, one free CPU will be allocated for each solver trial, but you can customize allocated CPUs/GPUs using the  `resources_per_trial` argument. \n",
+    "- Some solvers will fail for various reasons (e.g. missing required arguments, as logged in induvidual error.txt files under ~/ray_results arborescence), but this will not stop the benchmarck from running the other ones. So do not be afraid of the numerous red lines below!\n",
+    "- You could fix most of the failing solvers by specifying the missing arguments thanks to `solver_args` option as shown below for `StableBaseline`.\n",
+    "- To avoid a very long output, we use here a progress reporter adapted to Jupyter notebooks that will update in place the status of different jobs. As a side effect, error messages of failing solvers may be overwritten. But you can still have a look to the error files afterwards (see \"error file\" column in the second table below)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from stable_baselines3 import PPO  # this is a RL algorithm\n",
+    "\n",
+    "analysis = tune.run(\n",
+    "    training_function,\n",
+    "    config={\n",
+    "        \"solver\": tune.grid_search(benchmark_solvers),\n",
+    "        \"solver_args\": {  # Optional\n",
+    "            # Example of how to customize specific solver arguments (if needed):\n",
+    "            \"StableBaseline\": {\n",
+    "                \"algo_class\": PPO,\n",
+    "                \"baselines_policy\": \"MlpPolicy\",\n",
+    "                \"learn_config\": {\"total_timesteps\": 1000},\n",
+    "            }\n",
+    "        },\n",
+    "    },\n",
+    "    raise_on_failed_trial=False,\n",
+    "    progress_reporter=tune.JupyterNotebookReporter(overwrite=True),\n",
+    "    # time_budget_s = 60\n",
+    ")\n",
+    "\n",
+    "# Print (one of the) best solver, i.e. with maximum mean_episode_reward\n",
+    "best_config = analysis.get_best_config(metric=\"mean_episode_reward\", mode=\"max\")\n",
+    "print(\"==> Best solver:\", best_config[\"solver\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze results\n",
+    "\n",
+    "Let us get a dataframe for analyzing trial results and exporting them to a csv file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = analysis.results_df\n",
+    "df = df[df.done.notnull()]  # remove failed runs (avoids rows filled with NaN)\n",
+    "df.to_csv(\"benchmark_results.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we force displaying all columns, but the really interesting ones are the first two:\n",
+    "- `mean_episode_reward`: this is the objective function, namely the average reward on 10 episodes.\n",
+    "- `time_this_iter_s`: the computation time for the trial. \n",
+    "   Note that this includes the whole process coded in `training_function`, namely the solving time, but also the rollout time for computing `mean_episode_reward` which could add up some overhead depending on domain and solver.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from IPython.core.display import HTML, display\n",
+    "\n",
+    "\n",
+    "def force_show_all(df):\n",
+    "    with pd.option_context(\n",
+    "        \"display.max_rows\", None, \"display.max_columns\", None, \"display.width\", None\n",
+    "    ):\n",
+    "        display(HTML(df.to_html()))\n",
+    "\n",
+    "\n",
+    "force_show_all(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that Ray tune automatically generates Tensorboard files during `tune.run`, see the [documentation](https://docs.ray.io/en/latest/tune/user-guide.html#tensorboard-logging) for more details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "This concludes this benchmarking notebook, but we just scratched the surface of Ray Tune possibilties. Feel free to further experiment, for instance by fine tuning the hyperparameters of a specific solver to improve its results (the progress can sometimes be very significant)!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (cinb_env)",
+   "language": "python",
+   "name": "cinb_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.11"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "384px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This notebook shows how to use ray tune library to benchmark several solvers.

This PR is taking over PR #93 and adapt the benchmarking notebook. The main modifications are:
- pass a specific progress_reporter for jupyter to `tune.run` so that progress is updated in place
- display an html version of the dataframe instead of using bare `print`
- remove the tensorboard part which is not working on binder and finally not so relevant as there are only 1 point by solver and only 2 columns in the data really interesting
- add some explanations when needed

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/airbus/scikit-decide/binder?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fnhuet%252Fscikit-decide%26urlpath%3Dtree%252Fscikit-decide%252Fnotebooks%252F14_benchmarking_tuto.ipynb%26branch%3Dnh%252Fbenchmarking_nb_2)