### PR TITLE
Update notebook's kernel name and display name for default one (python3)

### DIFF
--- a/notebooks/14_benchmarking_tuto.ipynb
+++ b/notebooks/14_benchmarking_tuto.ipynb
@@ -257,9 +257,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (cinb_env)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "cinb_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
The current chosen kernel name (cinb_env) was specific to my configuration and it will be not found on a generic computer.

It results to
- a popup message asking for choosing the appropriate kernel when running locally (so not completely an error but still unsatisfactory)
- an error when testing the notebook with tool like nbmake with `pytest --nbmake`

We may want to add a pre-commit hook to check that later.