### PR TITLE
Trigger build  workflow for all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: 🔨 Build scikit-decide
 on:
   push:
     branches:
-      - "*"
+      - "**"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
With previous syntax, the workflow did not trigger on push on
branches with a slash in its name (e.g. nh/ci_all_branches).