### PR TITLE
Add option to strip kernelspec metadata from notebooks with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,4 +60,5 @@ repos:
     rev: 0.5.0
     hooks:
       - id: nbstripout
+        args: [--extra-keys=metadata.kernelspec]
         files: ^notebooks/

--- a/notebooks/11_maze_tuto.ipynb
+++ b/notebooks/11_maze_tuto.ipynb
@@ -685,11 +685,6 @@
  ],
  "metadata": {
   "anaconda-cloud": {},
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/12_gym_tuto.ipynb
+++ b/notebooks/12_gym_tuto.ipynb
@@ -860,11 +860,6 @@
  ],
  "metadata": {
   "anaconda-cloud": {},
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/13_scheduling_tuto.ipynb
+++ b/notebooks/13_scheduling_tuto.ipynb
@@ -941,11 +941,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/14_benchmarking_tuto.ipynb
+++ b/notebooks/14_benchmarking_tuto.ipynb
@@ -256,11 +256,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python (cinb_env)",
-   "language": "python",
-   "name": "cinb_env"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",


### PR DESCRIPTION
**Goal**: Avoid having weird non default kernels specified by accident in notebooks.

**Context**: If an unknown kernel is specified, local jupyter sessions will popup to ask for selecting among existing kernels. Testing notebooks with `pytest --nbmake` will crash.

**Pros**:
When removing the entire field "kernelspec" from metadatas, the notebooks will open in jupyter with the default kernel which is python3. This will also work with `pytest --nbmake` when testing notebooks.

**Cons**:
When saving the notebooks from a local Jupyter session, the kernelspec metadata will be restored. So the pre-commit will probably complain after each change if it has been installed as a git hook. So that pre-commit will need to be performed after each change.