### PR TITLE
Use docker modularly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,11 +89,6 @@ jobs:
         if: steps.cache-build-dependencies.outputs.cache-hit != 'true'
         run: echo "SKDECIDE_SKIP_DEPS=0" >> $GITHUB_ENV
 
-      - name: Set up Docker Buildx
-        if: matrix.os == 'ubuntu-latest'
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Install boost & omp on MacOS
         if: matrix.os == 'macos-10.15'
         run: brew install libomp
@@ -106,12 +101,28 @@ jobs:
           pip install build poetry-dynamic-versioning
           python -m build --sdist --wheel
 
+      - name: Restore docker dev image for Linux
+        id: cache-dev-deps
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/cache@v2.1.4
+        with:
+          path: /tmp/docker
+          key: dev-deps-${{ runner.os }}-${{ hashFiles('scripts/build-skdecide_dev.sh', 'scripts/build-pip-install.sh', 'scripts/Dockerfile_x86_64_dev') }}
+
       - name: Build x86 Linux wheels
         if: matrix.os == 'ubuntu-latest'
         run: |
-          DOCKER_BUILDKIT=1 docker build -t skdecide_x86_64 --build-arg PYTHON_VERSION=${{matrix.python-version}} --build-arg SKDECIDE_SKIP_DEPS=${{env.SKDECIDE_SKIP_DEPS}} --output type=local,dest=tmpwheelhouse -f scripts/Dockerfile_x86_64 .
-          mkdir -p dist
-          mv tmpwheelhouse/wheelhouse/*.whl dist/
+          # Load skdecide_dev image from cache, or build it if not found
+          if test -f /tmp/docker/skdecide_dev.tar; then
+            docker image load -i /tmp/docker/skdecide_dev.tar
+          else
+            docker build -f scripts/Dockerfile_x86_64_dev -t skdecide_dev .
+            mkdir -p /tmp/docker
+            docker image save -o /tmp/docker/skdecide_dev.tar skdecide_dev
+          fi
+          docker build -f scripts/Dockerfile_x86_64 -t skdecide_x86_64 --build-arg PYTHON_VERSION=${{matrix.python-version}} --build-arg SKDECIDE_SKIP_DEPS=${SKDECIDE_SKIP_DEPS} .
+          # Fetch wheels from Docker
+          docker run --rm -v $PWD:/mytmp skdecide_x86_64 cp -r /io/dist /mytmp
 
       - name: Update build cache from wheels
         if: steps.cache-build-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,6 @@ jobs:
         if: steps.cache-build-dependencies.outputs.cache-hit != 'true'
         run: echo "SKDECIDE_SKIP_DEPS=0" >> $GITHUB_ENV
 
-      - name: Set up Docker Buildx
-        if: matrix.os == 'ubuntu-latest'
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Install boost & omp on MacOS
         if: matrix.os == 'macos-10.15'
         run: brew install libomp
@@ -94,12 +89,28 @@ jobs:
           pip install build poetry-dynamic-versioning
           python -m build --sdist --wheel
 
+      - name: Restore docker dev image for Linux
+        id: cache-dev-deps
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/cache@v2.1.4
+        with:
+          path: /tmp/docker
+          key: dev-deps-${{ runner.os }}-${{ hashFiles('scripts/build-skdecide_dev.sh', 'scripts/build-pip-install.sh', 'scripts/Dockerfile_x86_64_dev') }}
+
       - name: Build x86 Linux wheels
         if: matrix.os == 'ubuntu-latest'
         run: |
-          DOCKER_BUILDKIT=1 docker build -t skdecide_x86_64 --build-arg PYTHON_VERSION=${{matrix.python-version}} --build-arg SKDECIDE_SKIP_DEPS=${{env.SKDECIDE_SKIP_DEPS}} --output type=local,dest=tmpwheelhouse -f scripts/Dockerfile_x86_64 .
-          mkdir -p dist
-          mv tmpwheelhouse/wheelhouse/*.whl dist/
+          # Load skdecide_dev image from cache, or build it if not found
+          if test -f /tmp/docker/skdecide_dev.tar; then
+            docker image load -i /tmp/docker/skdecide_dev.tar
+          else
+            docker build -f scripts/Dockerfile_x86_64_dev -t skdecide_dev .
+            mkdir -p /tmp/docker
+            docker image save -o /tmp/docker/skdecide_dev.tar skdecide_dev
+          fi
+          docker build -f scripts/Dockerfile_x86_64 -t skdecide_x86_64 --build-arg PYTHON_VERSION=${{matrix.python-version}} --build-arg SKDECIDE_SKIP_DEPS=${SKDECIDE_SKIP_DEPS} .
+          # Fetch wheels from Docker
+          docker run --rm -v $PWD:/mytmp skdecide_x86_64 cp -r /io/dist /mytmp
 
       - name: Update build cache from wheels
         if: steps.cache-build-dependencies.outputs.cache-hit != 'true'

--- a/scripts/Dockerfile_x86_64
+++ b/scripts/Dockerfile_x86_64
@@ -1,6 +1,9 @@
-FROM quay.io/pypa/manylinux2014_x86_64 as build
+ARG BASE_IMAGE=skdecide_dev
+
+FROM $BASE_IMAGE as build
 
 ENV PLAT=manylinux2014_x86_64
+
 RUN mkdir -p /io/
 COPY . /io/
 WORKDIR /io/
@@ -9,18 +12,5 @@ ARG CONDA_PREFIX=/opt/conda
 ARG PYTHON_VERSION=3.8
 ARG SKDECIDE_SKIP_DEPS=0
 ENV SKDECIDE_SKIP_DEPS=$SKDECIDE_SKIP_DEPS
-
-RUN yum install -y git zlib-devel
-# Install the latest boost library
-RUN curl -L https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz -o boost-1.76.0.tar.gz \
-    && tar xfz boost-1.76.0.tar.gz \
-    && rm boost-1.76.0.tar.gz \
-    && cd boost_1_76_0 \
-    && ./bootstrap.sh --help \
-    && ./bootstrap.sh --without-icu --with-libraries=headers --prefix=/usr/local \
-    && ./b2 install
 #
 RUN ./scripts/build-manylinux-wheels.sh $PYTHON_VERSION
-#
-FROM scratch as release
-COPY --from=build /io/dist /wheelhouse

--- a/scripts/Dockerfile_x86_64_dev
+++ b/scripts/Dockerfile_x86_64_dev
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64
+
+FROM $BASE_IMAGE as build
+
+RUN mkdir /scripts
+COPY scripts/build-skdecide_dev.sh scripts/build-pip-install.sh /scripts/
+
+RUN /scripts/build-skdecide_dev.sh

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -25,18 +25,18 @@ mkdir -p /io/temp-wheels
 # Clean out any old existing wheels.
 find /io/temp-wheels/ -type f -delete
 
+# pip upgrade and install cmake and auditwheel if it isn't already
+$(dirname $(realpath "$0"))/build-pip-install.sh
+
 # Uses the Python version requested as first argument, otherwise use 3.8 by default
 PYTHON_VERSION=${1:-3.8}
+#
 for PYBIN in /opt/python/cp${PYTHON_VERSION/./}*/bin; do
-    (cd /io/ && "${PYBIN}/python" -m pip install --upgrade -q pip)
-    (cd /io/ && "${PYBIN}/python" -m pip install build cmake)
     (cd /io/ && "${PYBIN}/python" -m build --sdist --wheel --outdir /io/temp-wheels)
     (cd /io/ && rm -rf build)
 done
 
 echo $PLAT
-
-"$PYBIN/pip" install -q auditwheel
 
 # Wheels aren't considered manylinux unless they have been through
 # auditwheel. Audited wheels go in /io/dist/.

--- a/scripts/build-pip-install.sh
+++ b/scripts/build-pip-install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -ex
+
+# upgrade python packages and install cmake and auditwheels packages
+
+# This script is called by the build-skdecide_dev.sh and build-manylinux-wheels.sh
+# scripts. In a workflow triggered by .github/workflow/build.yml or release.yml,
+# this script should be called first by build-skdecide_dev.sh.
+# The call from build-manylinux.sh should allow to manually run build-manylinux.sh
+# , as specified in its comments
+
+
+for PYTHON_VER in 3.7 3.8; do
+    python$PYTHON_VER -m pip install --upgrade -q pip
+    python$PYTHON_VER -m pip install build cmake
+done
+#install auditwheel for python 3.8 (used after the build in scripts/build-manylinux-wheels.sh)
+python3.8 -m pip install -q auditwheel

--- a/scripts/build-skdecide_dev.sh
+++ b/scripts/build-skdecide_dev.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+yum install -y git zlib-devel
+# Install the latest boost library
+curl -L https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz -o boost-1.76.0.tar.gz \
+    && tar xfz boost-1.76.0.tar.gz \
+    && rm boost-1.76.0.tar.gz \
+    && cd boost_1_76_0 \
+    && ./bootstrap.sh --help \
+    && ./bootstrap.sh --without-icu --with-libraries=headers --prefix=/usr/local \
+    && ./b2 install
+
+# pip upgrade and install cmake and auditwheel packages
+$(dirname $(realpath "$0"))/build-pip-install.sh


### PR DESCRIPTION
An initial docker image is now created for additional dependencies
through the new Dockerfile_x86_64_dev, build-skdecide_dev.sh and
build-pip-install.sh.
This image is cached to gain some time.

The skdecide_x86_64 image (building linux wheels) is created on top of
skdecide_dev through Dockerfile_x86_64, build-manylinux-wheels and
build-pip-install.sh.

The resulting docker image now contains all the files it created or loaded
and not just the output.

Fetching a file from the docker image can be done through a single
docker run --rm -v command in the .yml files

Also remove the setup of docker BUILD_KIT that wasn't used

build-pip-install.sh ensure that a build can still be done
manually as specified in the comments of build-manylinux.sh.
It is called both in build-skdecide_dev.sh, to be able to cache the
packages with the first docker image and in build-manylinux.sh
for manual builds.