### PR TITLE
Create specific binder env for each scikit-decide release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,8 +303,7 @@ jobs:
 
       - name: Update scikit-decide dependency and tag the environement
         run: |
-          sed -e "s/scikit-decide\[all\]==.*/scikit-decide\[all\]==${SKDECIDE_VERSION}/" environment.yml > environment.yml.new
-          mv environment.yml.new environment.yml
+          sed -i -e "s/scikit-decide\[all\]==.*/scikit-decide[all]==${SKDECIDE_VERSION}/" environment.yml
           git config user.name "Binder Bot"
           git config user.email "binder@bot.com"
           git commit environment.yml -m "Update scikit-decide dependency"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,63 +283,52 @@ jobs:
           packages_dir: wheels/
           repository_url: https://test.pypi.org/legacy/
 
-  create-binder-env:
-    needs: [deploy]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get scikit-decide release version and define new binder env tag
-        run: |
-          TAG_NAME=${GITHUB_REF/refs\/tags\//}  # stripping "refs/tags/"
-          SKDECIDE_VERSION=${TAG_NAME/v/}  # stripping "v"
-          BINDER_TAG=binder_${TAG_NAME}
-          echo "BINDER_TAG=${BINDER_TAG}" >> $GITHUB_ENV
-          echo "SKDECIDE_VERSION=${SKDECIDE_VERSION}" >> $GITHUB_ENV
-
-      # Checks-out binder branch
-      - name: checkout binder branch
-        uses: actions/checkout@v2
-        with:
-          ref: binder
-
-      - name: Update scikit-decide dependency and tag the environement
-        run: |
-          sed -i -e "s/scikit-decide\[all\]==.*/scikit-decide[all]==${SKDECIDE_VERSION}/" environment.yml
-          git config user.name "Binder Bot"
-          git config user.email "binder@bot.com"
-          git commit environment.yml -m "Update scikit-decide dependency"
-          git tag -a ${BINDER_TAG} -m "Release binder environment for scikit-decide ${SKDECIDE_VERSION}"
-          git push origin ${BINDER_TAG}
-
-      - name: Cache binder build on mybinder.org
-        uses: jupyterhub/repo2docker-action@master
-        with:
-          NO_PUSH: true
-          MYBINDERORG_TAG: ${{ env.BINDER_TAG }}
-
   build-docs:
-    needs: [create-binder-env]
+    needs: [deploy]
     runs-on: ubuntu-latest
     env:
       DOCS_VERSION_PATH: /
 
     steps:
-      - name: Set env variables for github+binder links in doc
+      - name: Get scikit-decide release version and update online docs path
         run: |
           TAG_NAME=${GITHUB_REF/refs\/tags\//}  # stripping "refs/tags/"
-          BINDER_TAG=binder_${TAG_NAME}
-          echo "AUTODOC_BINDER_ENV_GH_REPO_NAME=airbus/scikit-decide" >> $GITHUB_ENV
-          echo "AUTODOC_BINDER_ENV_GH_BRANCH=${BINDER_TAG}" >> $GITHUB_ENV
-          echo "AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
-          echo "AUTODOC_NOTEBOOKS_BRANCH=${TAG_NAME}" >> $GITHUB_ENV
+          SKDECIDE_VERSION=${TAG_NAME/v/}  # stripping "v"
+          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
+          echo "SKDECIDE_VERSION=${SKDECIDE_VERSION}" >> $GITHUB_ENV
+          echo "DOCS_VERSION_PATH=/version/$SKDECIDE_VERSION/" >> $GITHUB_ENV
 
-      - name: Update DOCS_VERSION_PATH
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: |
-            echo DOCS_VERSION_PATH=/version/${GITHUB_REF/refs\/tags\/v}/ >> $GITHUB_ENV
-
-      - uses: actions/checkout@v2
+      - name: Checkout all branches
+        uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-depth: 0  # fetch all branches
+
+      - name: Create binder environment for the release
+        run: |
+          git checkout binder
+          # Specify scikit-decide dependency for the release binder env
+          sed -i -e "s/scikit-decide\[all\]==.*/scikit-decide[all]==${SKDECIDE_VERSION}/" environment.yml
+          git config user.name "Actions"
+          git config user.email "actions@github.com"
+          git commit environment.yml -m "Specify scikit-decide used by binder for release ${SKDECIDE_VERSION}"
+          # get sha1 to be used by binder for the environment
+          BINDER_RELEASE_ENV_SHA1=$(git rev-parse --verify HEAD)
+          echo "BINDER_RELEASE_ENV_SHA1=${BINDER_RELEASE_ENV_SHA1}" >> $GITHUB_ENV
+          # revert for the master binder env
+          git revert HEAD -n
+          git commit -m "Revert to binder environment for master branch"
+          # push binder branch so that reference to release binder env exists on remote
+          git push origin binder
+          # switch back to original branch
+          git checkout $TAG_NAME
+
+      - name: Set env variables for github+binder links in doc
+        run: |
+          echo "AUTODOC_BINDER_ENV_GH_REPO_NAME=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          echo "AUTODOC_BINDER_ENV_GH_BRANCH=${BINDER_RELEASE_ENV_SHA1}" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_BRANCH=${TAG_NAME}" >> $GITHUB_ENV
 
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,8 +283,42 @@ jobs:
           packages_dir: wheels/
           repository_url: https://test.pypi.org/legacy/
 
-  build-docs:
+  create-binder-env:
     needs: [deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get scikit-decide release version and define new binder env tag
+        run: |
+          TAG_NAME=${GITHUB_REF/refs\/tags\//}  # stripping "refs/tags/"
+          SKDECIDE_VERSION=${TAG_NAME/v/}  # stripping "v"
+          BINDER_TAG=binder_${TAG_NAME}
+          echo "BINDER_TAG=${BINDER_TAG}" >> $GITHUB_ENV
+          echo "SKDECIDE_VERSION=${SKDECIDE_VERSION}" >> $GITHUB_ENV
+
+      # Checks-out binder branch
+      - name: checkout binder branch
+        uses: actions/checkout@v2
+        with:
+          ref: binder
+
+      - name: Update scikit-decide dependency and tag the environement
+        run: |
+          sed -e "s/scikit-decide\[all\]==.*/scikit-decide\[all\]==${SKDECIDE_VERSION}/" environment.yml > environment.yml.new
+          mv environment.yml.new environment.yml
+          git config user.name "Binder Bot"
+          git config user.email "binder@bot.com"
+          git commit environment.yml -m "Update scikit-decide dependency"
+          git tag -a ${BINDER_TAG} -m "Release binder environment for scikit-decide ${SKDECIDE_VERSION}"
+          git push origin ${BINDER_TAG}
+
+      - name: Cache binder build on mybinder.org
+        uses: jupyterhub/repo2docker-action@master
+        with:
+          NO_PUSH: true
+          MYBINDERORG_TAG: ${{ env.BINDER_TAG }}
+
+  build-docs:
+    needs: [create-binder-env]
     runs-on: ubuntu-latest
     env:
       DOCS_VERSION_PATH: /
@@ -292,10 +326,12 @@ jobs:
     steps:
       - name: Set env variables for github+binder links in doc
         run: |
+          TAG_NAME=${GITHUB_REF/refs\/tags\//}  # stripping "refs/tags/"
+          BINDER_TAG=binder_${TAG_NAME}
           echo "AUTODOC_BINDER_ENV_GH_REPO_NAME=airbus/scikit-decide" >> $GITHUB_ENV
-          echo "AUTODOC_BINDER_ENV_GH_BRANCH=binder" >> $GITHUB_ENV
+          echo "AUTODOC_BINDER_ENV_GH_BRANCH=${BINDER_TAG}" >> $GITHUB_ENV
           echo "AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
-          echo "AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_BRANCH=${TAG_NAME}" >> $GITHUB_ENV
 
       - name: Update DOCS_VERSION_PATH
         if: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
**Summary**:
During release.yml workflow, we push a new tag  defining the corresponding binder environment, then build and cache it on mybinder.org. Finally the binder links in the release doc point to this specific environment.

**Hypotheses**:
- a branch named "binder" exists on the repository with an environment.yml file  used to define a binder env
- the branch is up-to-date with necessary dependencies to make work the notebooks on master with master version of scikit-decide
- environment.yml file contains the dependency in scikit-decide, and it follows the format `scikit-decide[all]==...`

**Process**:
- we checkout binder branch
- we replace the spec for scikit-decide by the scikit-decide version corresponding to the release triggering the workflow
- we commit and push a tag named "binder_vx.x.x" where x.x.x stands for the inferred version number
- we force a build of the environment on mybinder.org to accelerate later call to it
- we use this binder env for links in the doc for the release

Note:  we used a quite verbose way to define the BINDER_TAG variable. This is to make it clear that we create it exactly the same way in both jobs "create-binder-env" and "build-docs" , as there is no simple way to share variables between jobs (without using artifacts).


A fake release v0.9.3 has been created on nhuet/scikit-decide to test that the binder environment is well defined. 
When the workflow will be finished, we should have a tag "binder_v0.9.3" (see https://github.com/nhuet/scikit-decide/tree/binder_v0.9.3 ) defining the binder environment with scikit-decide 0.9.3 (from pypi), and the environment should have been prebuilt on mybinder.org. Test this link: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nhuet/scikit-decide/binder_v0.9.3?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fnhuet%252Fscikit-decide%26urlpath%3Dtree%252Fscikit-decide%252Fnotebooks%252F11_maze_tuto.ipynb%26branch%3Dv0.9.3)