### PR TITLE
Choosing node version explicitely

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - name: Download artifacts
         uses: actions/download-artifact@v1.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,10 @@ jobs:
         with:
           python-version: "3.7"
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - name: Download artifacts
         uses: actions/download-artifact@v1.0.0
         with:


### PR DESCRIPTION
Node version is forced to 14 to avoid doc generation crash