### PR TITLE
Speed up build workflow with ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,19 @@ jobs:
         if: matrix.os == 'macos-10.15'
         run: brew install libomp
 
+      - name: Install and restore ccache for macOs
+        if: matrix.os == 'macos-10.15'
+        uses: hendrikmuhs/ccache-action@v1.0.5
+        with:
+          key: ${{ runner.os }}-py${{ matrix.python-version }}
+          max-size: 80M
+
+      - name: Let cmake use ccache for macOs
+        if: matrix.os == 'macos-10.15'
+        run: |
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> ${GITHUB_ENV}
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> ${GITHUB_ENV}
+
       - name: Build macOS/Windows wheel
         if: matrix.os != 'ubuntu-latest'
         run: |
@@ -103,6 +116,15 @@ jobs:
           path: /tmp/docker
           key: dev-deps-${{ runner.os }}-${{ hashFiles('scripts/build-skdecide_dev.sh', 'scripts/build-pip-install.sh', 'scripts/Dockerfile_x86_64_dev') }}
 
+      - name: Restore ccache cache for Linux
+        id: ccache-restore
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/cache@v2.1.4
+        with:
+          path: .ccache
+          key: ccache-${{ runner.os }}-py${{ matrix.python-version }}-${{ github.run_id }}-${{github.run_number}}
+          restore-keys: ccache-${{ runner.os }}-py${{ matrix.python-version }}
+
       - name: Build x86 Linux wheels
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -114,9 +136,13 @@ jobs:
             mkdir -p /tmp/docker
             docker image save -o /tmp/docker/skdecide_dev.tar skdecide_dev
           fi
+          # The existence of .ccache directory triggers ccache use in builds-manylinux-wheels.sh
+          test -d .ccache || mkdir .ccache
           docker build -f scripts/Dockerfile_x86_64 -t skdecide_x86_64 --build-arg PYTHON_VERSION=${{matrix.python-version}} --build-arg SKDECIDE_SKIP_DEPS=${SKDECIDE_SKIP_DEPS} --build-arg BOOST_DIR=${BOOST_DIR} .
           # Fetch wheels from Docker
           docker run --rm -v $PWD:/mytmp skdecide_x86_64 cp -r /io/dist /mytmp
+          # Fetch ccache from Docker
+          docker run --rm -v $PWD:/mytmp skdecide_x86_64 cp -r /io/.ccache /mytmp
 
       - name: Update build cache from wheels
         if: steps.cache-build-dependencies.outputs.cache-hit != 'true'

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -25,6 +25,16 @@ mkdir -p /io/temp-wheels
 # Clean out any old existing wheels.
 find /io/temp-wheels/ -type f -delete
 
+
+#ccache setup
+if test -d .ccache; then
+    export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+    export CMAKE_C_COMPILER_LAUNCHER=ccache
+    ccache --set-config cache_dir=$PWD/.ccache
+    ccache --set-config max_size=80M
+    ccache --set-config compression=true
+fi
+
 # pip upgrade and install cmake and auditwheel if it isn't already
 $(dirname $(realpath "$0"))/build-pip-install.sh
 

--- a/scripts/build-skdecide_dev.sh
+++ b/scripts/build-skdecide_dev.sh
@@ -2,6 +2,7 @@
 set -ex
 
 yum install -y git zlib-devel
+yum install -y ccache
 
 # pip upgrade and install cmake and auditwheel packages
 $(dirname $(realpath "$0"))/build-pip-install.sh


### PR DESCRIPTION
Use ccache to speed up C and C++ compilation triggered by build.yml.
This only affect MacOs and Linux runners.

For MacOs, installation, configuration and github caching is done
through the hendrikmuhs/ccache action.
Cmake is set to use ccache through the env variable CMAKE_*_COMPILER_LAUNCHER.

For Linux, installation is done in build-skdecide_dev, config and link with
Cmake in build-many-linux-wheels.sh.
The cache directory is fetched from the docker image to the .ccache directory
to be cached by the default github cache action and reused in later runs

For Linux, the setup is gated by the existence of .ccache directory that is either
restored from github cache or created in Build_x86_64. This ensure that release.yml
doesn't use ccache while still sharing the dockerfiles and scripts used by build.yml.

For both runners, ccache is configured to use compression (by default for the version used by macOs)
and limits cache size to 80M.

Note that for the cache to be saved by github, a new one is created every run.