### PR TITLE
Fix libminizinc build when ccache is installed

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -201,6 +201,7 @@ def build(setup_kwargs: Dict[str, Any]) -> None:
                     install_prefix="skdecide/hub",
                     cmake_configure_options=[
                         f"-DBUILD_SHARED_LIBS:BOOL=OFF",
+                        f"-DUSE_CCACHE:BOOL=OFF",
                     ],
                 ),
             ]


### PR DESCRIPTION
CMake 3.4 added native support for ccache and distcc, by setting CMAKE_\<lang>_COMPILER_LAUNCHER variables.

But libminizinc option USE_CCACHE is harmful, it adds ccache again to the command line, and there is a build error:
```
ccache: error: Recursive invocation (the name of the ccache binary must be "ccache")
```
We did not see it in previous build because the cache on build dependencies was hit.
