### PR TITLE
Automatically cancel running jobs when pushing commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron:  '45 1 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint-sources:


### PR DESCRIPTION
Documentation mentions github.ref and github.head_ref
  https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

Let us consider a branch "foo" being pushed on a forked repository:
  github.head_ref:
  * Pull request: "foo"
  * Push: ""
  github.ref:
  * Pull request: "refs/pulls/\<PR-id>/merge"
  * Push:  "refs/heads/foo"

github.ref seems to be what we want.