### PR TITLE
Binder env: install scikit-decide from last nightly build 

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,3 +1,4 @@
+jq
 ffmpeg
 freeglut3-dev
 xvfb

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
     - matplotlib
     - ipywidgets
     - ipympl
-    - scikit-decide[all]==0.9.2
     - nbgitpuller
     - pyvirtualdisplay
     - PyOpenGL-accelerate

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Last nightly build
+# Last nightly build: No new nightly release
 NIGHTLY_TAG="nightly"
 NIGHTLY_REPO="galleon/scikit-decide"
 

--- a/postBuild
+++ b/postBuild
@@ -1,23 +1,26 @@
 #!/bin/bash
 
+# Stops if an error occurs
+set -e
+
 # Last nightly build: No new nightly release
 NIGHTLY_TAG="nightly"
 NIGHTLY_REPO="galleon/scikit-decide"
 
 # Install scikit-decide from last nightly build if not yet installed
-skdecide_version=$(pip list | grep "scikit-decide")
+skdecide_version=$(pip list | grep "scikit-decide" | head -n 1)
 if [ -z "${skdecide_version}" ]; then
   echo "Scikit-decide not found: installing from last nightly build."
   # get last nightly build asset url
   asset_url=$(\
     curl -s https://api.github.com/repos/${NIGHTLY_REPO}/releases \
     | jq -c ".[] | select( .tag_name == \"$NIGHTLY_TAG\" ) | .assets|sort_by(.createdAt)|.[-1].browser_download_url" \
-    | sed -e 's/\"//g'
+    | sed -e 's/"//g'
   )
   # check that it exists (either "null" is no asset in nightly or "" if no tag nightly at all)
   if  [ $asset_url == "null" ] || [ $asset_url == "" ]; then
     echo "No nightly build available. Falling back to last version in pypi."
-    pip install sickit-decide[all]
+    pip install scikit-decide[all]
   else
     # download and unzip
     wget --output-document=nightly.zip ${asset_url}

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Last nightly build
+NIGHTLY_TAG="nightly"
+NIGHTLY_REPO="galleon/scikit-decide"
+
+# Install scikit-decide from last nightly build if not yet installed
+skdecide_version=$(pip list | grep "scikit-decide")
+if [ -z "${skdecide_version}" ]; then
+  echo "Scikit-decide not found: installing from last nightly build."
+  # get last nightly build asset url
+  asset_url=$(\
+    curl -s https://api.github.com/repos/${NIGHTLY_REPO}/releases \
+    | jq -c ".[] | select( .tag_name == \"$NIGHTLY_TAG\" ) | .assets|sort_by(.createdAt)|.[-1].browser_download_url" \
+    | sed -e 's/\"//g'
+  )
+  # check that it exists (either "null" is no asset in nightly or "" if no tag nightly at all)
+  if  [ $asset_url == "null" ] || [ $asset_url == "" ]; then
+    echo "No nightly build available. Falling back to last version in pypi."
+    pip install sickit-decide[all]
+  else
+    # download and unzip
+    wget --output-document=nightly.zip ${asset_url}
+    unzip nightly.zip
+    # get the appropriate wheel from python version
+    wheel_pythonversion_tag=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
+    wheel_path=$(ls dist/scikit_decide*${wheel_pythonversion_tag}*manylinux*.whl)
+    # install scikit-decide with all extras
+    pip install ${wheel_path}[all]
+  fi
+else
+  echo "Scikit-decide already installed."
+fi


### PR DESCRIPTION
We remove scikit-decide dependency from environment.yml so that the installation is done in postBuild:
- only if scikit-decide not yet installed (so that release env are not  affected as they will have scikit-decide specified in environment.yml)
- we use github rest api and jq parser to extract download url for last nightly build from "nightly" release
- if not available (no tag or no asset), we fall back to plain `pip install scikit-decide` which will pull from pypi
- else we unzip and install appropriate wheel

Notes: 
- for now we download the nightly build from galleon/scikit-decide, but we will switch to airbus/scikit-decide once the first nightly release is done there.
- one can test the resulting environemnt here: https://mybinder.org/v2/gh/nhuet/scikit-decide/binder then open a notebook and test `import skdecide; skdecide.__version__` in a cell.
- in order to have really the *last* nightly build, we have to force a rebuild of this branch ("binder") when building a new nightly release. This will be done in a new PR by modifying master's build.yml.  The only way is by making a push to the "binder" branch. (see [below](https://github.com/airbus/scikit-decide/pull/139#issuecomment-987942953))