### PR TITLE
Adding scikikit decide to environment.yml with appropriate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,7 @@ jobs:
         run: |
           git checkout binder
           # Specify scikit-decide dependency for the release binder env
-          sed -i -e "s/scikit-decide\[all\]==.*/scikit-decide[all]==${SKDECIDE_VERSION}/" environment.yml
+          echo "    - scikit-decide[all]==${SKDECIDE_VERSION}" >> environment.yml
           git config user.name "Actions"
           git config user.email "actions@github.com"
           git commit environment.yml -m "Specify scikit-decide used by binder for release ${SKDECIDE_VERSION}"


### PR DESCRIPTION
@nhuet I am pushing what I have done on the topic. It is slightly different from your work since here the default environment in not having `scikit-decide` in `environment.yml`
`scikit-decide` install is delegated to  `postBuild`  following this rule(your rule):
-  install the latest `nightly`
- if it does not exist install the latest release

Your code mostly stays the same. The `sed` is transformed in `echo`

I have tried to add `scikit-decide` dependencies in the `environment.yml` in case a first image is generated with it - then the `postBuild` will take less time (to be assessed). I have tried it using directly the SHA1 in my `binder`branch using links like this one:
https://mybinder.org/v2/gh/galleon/scikit-decide/<SHA1>?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fgalleon%252Fscikit-decide%26urlpath%3Dtree%252Fscikit-decide%252Fnotebooks%252F11_maze_tuto.ipynb%26branch%3Dmaster

where SHA1 is HEAD for `nighly`or the SHA1 for the specific versions in case I want one of those.
