### PR TITLE
Fix unbalanced parenthesis in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,7 +375,7 @@ jobs:
               repo: context.repo.repo,
             })
 
-            const nightlyRelease = releases.data.find(r => r.tag_name === 'nightly'))
+            const nightlyRelease = releases.data.find(r => r.tag_name === 'nightly')
 
             if (nightlyRelease) {
               await github.rest.repos.deleteRelease({


### PR DESCRIPTION
Changed line 378 from 
`const nightlyRelease = releases.data.find(r => r.tag_name === 'nightly'))
`to
`const nightlyRelease = releases.data.find(r => r.tag_name === 'nightly')`