### PR TITLE
Trigger a build of release binder env on mybinder.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,6 +505,13 @@ jobs:
           # switch back to original branch
           git checkout $TAG_NAME
 
+      - name: Trigger a build on each BinderHub deployments in the mybinder.org federation
+        run: |
+          bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
+
       - name: Set env variables for github+binder links in doc
         run: |
           echo "AUTODOC_BINDER_ENV_GH_REPO_NAME=${GITHUB_REPOSITORY}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,10 +507,10 @@ jobs:
 
       - name: Trigger a build on each BinderHub deployments in the mybinder.org federation
         run: |
-          bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
-          bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
-          bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
-          bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/nhuet/scikit-decide/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
 
       - name: Set env variables for github+binder links in doc
         run: |

--- a/scripts/trigger_binder.sh
+++ b/scripts/trigger_binder.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# from https://github.com/scikit-hep/pyhf/blob/master/binder/trigger_binder.sh
+
+function trigger_binder() {
+    local URL="${1}"
+
+    curl -L --connect-timeout 10 --max-time 12 "${URL}"
+    curl_return=$?
+
+    # Return code 28 is when the --max-time is reached
+    if [ "${curl_return}" -eq 0 ] || [ "${curl_return}" -eq 28 ]; then
+        if [[ "${curl_return}" -eq 28 ]]; then
+            printf "\nBinder build started.\nCheck back soon.\n"
+        fi
+    else
+        return "${curl_return}"
+    fi
+
+    return 0
+}
+
+function main() {
+    # 1: the Binder build API URL to curl
+    trigger_binder $1
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
The goal is to reduce the starting time for real users. Indeed,
according to the mybinder documentation, the build step occurs only the
first time the binderhub launches a jupyter session for a repo with an updated ref. Cf https://mybinder.readthedocs.io/en/latest/about/about.html#what-factors-influence-how-long-it-takes-a-binder-session-to-start

We use a script taken from https://github.com/scikit-hep/pyhf/blob/master/binder/trigger_binder.sh
to ping the endpoints of each binderhub in the mybinder.org federation.
(cf https://mybinder.readthedocs.io/en/latest/about/federation.html)

We do not need to stay connected to the binderhub for the build to go on, so the trigger step in the workflow takes less than 1' as one can see in the workflow generated by a fake release on my fork: https://github.com/nhuet/scikit-decide/runs/4505623076?check_suite_focus=true 
We can see that the build has been done for the commit corresponding to the updated binder environment:
https://mybinder.org/v2/gh/nhuet/scikit-decide/a0e09be06f993f0000b4d6c4a2908f7eec3e266f

(Here you have to trust me for not having follow this link before the workflow took place :)

