### PR TITLE
Fix copy-paste in code generator

### DIFF
--- a/docs/.vuepress/components/skdecide-codegen.vue
+++ b/docs/.vuepress/components/skdecide-codegen.vue
@@ -45,7 +45,7 @@
   <span class="token keyword">class</span> <template v-if="isSolver"><span class="token class-name">MySolver</span>({{ solverInheritance }}):
       T_domain <span class="token operator">=</span> D</template><template v-else><span class="token class-name">MyDomain</span>(D):</template>
       <template v-for="[characteristic, level] in Object.entries({...{'default': domainOrSolver}, ...selection[domainOrSolver].characteristics}).filter(([k, v]) => v != '(none)')"><template v-for="method in methods[domainOrSolver][level]">
-      <span class="token keyword">def</span> <span class="token function">{{method}}</span>(<template v-for="p, i in signatures[method].params">{{p.name}}<template v-if="p.annotation">: {{adaptAnnotation(p.annotation)}}</template><span v-show="p.default"> <span class="token operator">=</span> <span class="token boolean">{{p.default}}</span></span><span v-show="i < signatures[method].params.length - 1">, </span></template>)<template v-if="signatures[method].return"> <span class="token operator">-></span> {{adaptAnnotation(signatures[method].return)}}</template>:
+      <span class="token keyword">def</span> <span class="token function">{{method}}</span>(<template v-for="p, i in signatures[method].params">{{p.name}}<template v-if="p.annotation">: {{adaptAnnotation(p.annotation)}}</template><template v-if="p.default"> <span class="token operator">=</span> <span class="token boolean">{{p.default}}</span></template><template v-if="i < signatures[method].params.length - 1">, </template></template>)<template v-if="signatures[method].return"> <span class="token operator">-></span> {{adaptAnnotation(signatures[method].return)}}</template>:
           <span class="token keyword">pass</span>
       </template></template>
   </code>

--- a/docs/autodoc.py
+++ b/docs/autodoc.py
@@ -123,7 +123,12 @@ def add_func_method_infos(func_method, autodoc):
     for k, v in parameters.items():
         if not (k == "self" and func_method.__name__ == "__init__"):
             parameter = parameters[k]
-            param = {"name": k}
+            if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+                param = {"name": "*" + k}
+            elif parameter.kind == inspect.Parameter.VAR_KEYWORD:
+                param = {"name": "**" + k}
+            else:
+                param = {"name": k}
             if parameter.default != signature.empty:
                 param["default"] = str(parameter.default)
                 if "lambda" in param["default"]:


### PR DESCRIPTION
Replace v-show par v-if for default values:
 * with v-show, body tag is printed with a "display: none" CSS property.
   It is not visible, but copied nevertheless into clipboard.
 * with v-if, body tag is not printed.

Modify autodoc.py to print one or two asterisks before positional
and keyword arguments.

Fix issue #110.