### PR TITLE
Fix #133 (Docs is not building with node 16)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,10 +486,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-
       - name: Download artifacts
         uses: actions/download-artifact@v1.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,10 +517,6 @@ jobs:
         with:
           python-version: "3.7"
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-
       - name: Download artifacts
         uses: actions/download-artifact@v1.0.0
         with:

--- a/docs/.vuepress/components/skdecide-signature.vue
+++ b/docs/.vuepress/components/skdecide-signature.vue
@@ -11,6 +11,9 @@ export default {
     sig: {type: Object, default: () => ({params: []})},
     name: {type: String, default: ''}
   },
+  mounted() {
+    this.updateLinks()
+  },
   data () {
     return {
       needsLinksUpdate: false
@@ -63,7 +66,6 @@ export default {
       //adaptedAnnotation = adaptedAnnotation.replace(/\w+/g, match => (this.objects[match] !== undefined ? ('<a href="' + this.objects[match] + '">' + match + '</a>') : match))
       adaptedAnnotation = adaptedAnnotation.replace(/\w+/g, match => (this.objects[match] !== undefined ? ('<a class="linkto" data-link="' + this.objects[match] + '">' + match + '</a>') : match))
       this.needsLinksUpdate = true
-      this.$nextTick(this.updateLinks)
       return adaptedAnnotation
     },
     updateLinks () {


### PR DESCRIPTION
Call the function updateLinks() which references document (ie DOM)
inside a `mounted` hook.

Indeed the previous code was working with `yarn vuepress dev docs` but
not with `yarn vuepress build docs` because when *building*, vue uses a
server to generate the static website and usually `document` is only
available on client side.

However this is possible when inside the mounted hook
(https://vuepress.vuejs.org/guide/using-vue.html#browser-api-access-restrictions)

NB: no idea why this was working with node 14 though...