### PR TITLE
Remove toc for generated pages of the api reference

### DIFF
--- a/docs/autodoc.py
+++ b/docs/autodoc.py
@@ -408,9 +408,6 @@ if __name__ == "__main__":
         if "doc" in module:
             md += f'{module["doc"]}\n\n'
 
-        # Write Table Of Content
-        md += "[[toc]]\n\n"
-
         # Write domain spec summary
         md += "::: tip\n<skdecide-summary></skdecide-summary>\n:::\n\n"
 


### PR DESCRIPTION
Following a remark from @neo-alex, this PR remove the table of contents at the top of each generated reference page.
Indeed this was generally not readable and was a duplicate of sidebar menu, as shown in this screenshot:
![Screenshot from 2021-12-14 11-36-39](https://user-images.githubusercontent.com/23269019/145982384-23e074e3-2a9d-4380-afc7-6fd4a1528eeb.png)


## New version:
![Screenshot from 2021-12-14 11-38-53](https://user-images.githubusercontent.com/23269019/145982802-d974c8e8-f6a1-46ea-95e4-ae8bf59fce17.png)

One can check the whole website with the following process:
- downloading the "doc" artifact from the "Build scikit-decide" action triggered by this PR 
- unzip and serving it with
 ```shell
  mkdir testdoc
  cd testdoc
  unzip path/to/doc.zip -d scikit-decide
  python -m http.server
  ```
  