### PR TITLE
Make update of scikit-decide dependency more robust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,7 +490,7 @@ jobs:
         run: |
           git checkout binder
           # Specify scikit-decide dependency for the release binder env
-          sed -i -e "s/scikit-decide\[all\]==.*/scikit-decide[all]==${SKDECIDE_VERSION}/" environment.yml
+          sed -i -e "s/\(scikit-decide[^=]*==\).*/\1${SKDECIDE_VERSION}/" environment.yml
           git config user.name "Actions"
           git config user.email "actions@github.com"
           git commit environment.yml -m "Specify scikit-decide used by binder for release ${SKDECIDE_VERSION}"


### PR DESCRIPTION
In commit 4c4f00452, environment.yml is modified to depend on the exact
scikit-decide version being built.
The sed command assumed that environment.yml includes a line

    scikit-decide[all]==<some-version-number>

This commit makes the sed command more robust, it will now work whatever
extras section is used (it may also not be set).