### PR TITLE
Modify titles of domain/solver specification boxes

### DIFF
--- a/docs/.vuepress/components/skdecide-summary.vue
+++ b/docs/.vuepress/components/skdecide-summary.vue
@@ -1,7 +1,5 @@
 <template>
   <div style="margin: 10px 0px">
-    <span>{{ isSolver ? 'Solver' : 'Domain' }} specification:</span>
-
     <div style="margin-top: 5px; margin-bottom: 10px">
     <!-- Template -->
     <el-tag type="danger" effect="dark" style="margin-bottom: 5px">

--- a/docs/autodoc.py
+++ b/docs/autodoc.py
@@ -412,7 +412,7 @@ if __name__ == "__main__":
         md += "[[toc]]\n\n"
 
         # Write domain spec summary
-        md += "::: tip\n<skdecide-summary></skdecide-summary>\n:::\n\n"
+        md += "::: tip Domain specification\n<skdecide-summary></skdecide-summary>\n:::\n\n"
 
         # Write members
         for member in module["members"]:

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -1,6 +1,6 @@
 # Code generators
 
-::: tip
+::: tip Domain specification
 <skdecide-summary></skdecide-summary>
 :::
 
@@ -8,7 +8,7 @@
 
 <template v-slot:SolverSummary>
 
-::: warning
+::: warning Solver specification
 <skdecide-summary isSolver></skdecide-summary>
 :::
 


### PR DESCRIPTION
Following a suggestion of @neo-alex , the boxes should not have "TIP" and "WARNING" titles but rather "Domain specification" and "Solver specification". (The type of boxes are only here to format highlight them)

Previously:

![Screenshot from 2021-12-14 12-20-54](https://user-images.githubusercontent.com/23269019/145989039-60de3c0c-fc7a-432c-94da-d4e7383dfbd2.png)

New version:

![Screenshot from 2021-12-14 12-21-41](https://user-images.githubusercontent.com/23269019/145989112-39a5c81f-5aa0-4102-90ba-8a798691b734.png)

One can check the whole new generated website with the following process:
- downloading the "doc" artifact from the "Build scikit-decide" action triggered by this PR 
- unzip and serving it with
 ```shell
  mkdir testdoc
  cd testdoc
  unzip path/to/doc.zip -d scikit-decide
  python -m http.server
  ```