### PR TITLE
Provide filters for ci builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
       python_version: ${{ steps.generate-matrix.outputs.python_version }}
       build: ${{ steps.generate-matrix.outputs.build}}
       test: ${{ steps.generate-matrix.outputs.test}}
+      do_macos: ${{ steps.generate-matrix.outputs.do_macos}}
+      do_ubuntu: ${{ steps.generate-matrix.outputs.do_ubuntu}}
+      do_windows: ${{ steps.generate-matrix.outputs.do_windows}}
+      build_doc: ${{ steps.generate-matrix.outputs.build_doc}}
     steps:
       - uses: actions/setup-python@v2
       - name: Generate Matrix
@@ -33,11 +37,52 @@ jobs:
         shell: python3 {0}
         run: |
           python_version = ["3.7", "3.8", "3.9"]
-          build = { "macos": ["macos-10.15"], "linux": ["ubuntu-latest"], "windows": ["windows-2016"] }
-          test = { "macos": ["macos-10.15", "macos-11"], "linux": ["ubuntu-18.04", "ubuntu-20.04"], "windows": ["windows-2016", "windows-2019", "windows-2022"] }
+          build = [ "macos-10.15", "ubuntu-latest", "windows-2016" ]
+          test = [ "macos-10.15", "macos-11", "ubuntu-18.04", "ubuntu-20.04", "windows-2016", "windows-2019", "windows-2022"]
+          build_doc = "true"
+
+          if "${{ github.event_name }}" != "schedule":
+              to_bool = lambda s: True if s == "true" else False
+              python_filter = {
+                  '3.7' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.7]') }}"),
+                  '3.8' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.8]') }}"),
+                  '3.9' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.9]') }}"),
+              }
+              if any(python_filter.values()):
+                  python_version = [v for v in python_version if python_filter[v]]
+              os_filter = {
+                  'macos-10.15'  : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-10.15]') }}"),
+                  'macos-11'     : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-11]') }}"),
+                  'ubuntu-18.04' : to_bool("${{ contains(github.event.head_commit.message, '[ci: ubuntu-18.04]') }}"),
+                  'ubuntu-20.04' : to_bool("${{ contains(github.event.head_commit.message, '[ci: ubuntu-20.04]') }}"),
+                  'windows-2016' : to_bool("${{ contains(github.event.head_commit.message, '[ci: windows-2016]') }}"),
+                  'windows-2019' : to_bool("${{ contains(github.event.head_commit.message, '[ci: windows-2019]') }}"),
+                  'windows-2022' : to_bool("${{ contains(github.event.head_commit.message, '[ci: windows-2022]') }}"),
+              }
+              if set(os_filter.keys()) != set(test):
+                  raise Exception("test and os_filter do not contain the same keys")
+              if "${{ contains(github.event.head_commit.message, '[ci: windows]') }}" == "true":
+                  os_filter.update({k: True for k in os_filter if k.startswith("windows")})
+              if "${{ contains(github.event.head_commit.message, '[ci: macos]') }}" == "true":
+                  os_filter.update({k: True for k in os_filter if k.startswith("macos")})
+              if "${{ contains(github.event.head_commit.message, '[ci: ubuntu]') }}" == "true":
+                  os_filter.update({k: True for k in os_filter if k.startswith("ubuntu")})
+              # If there is no keyword, proceed as if all were present
+              if not any(os_filter.values()):
+                  os_filter.update({k: True for k in os_filter})
+              test = [ v for v in test if os_filter[v]]
+              test_os = { v.split('-')[0] for v in test }
+              build = [ v for v in build if v.split('-')[0] in test_os ]
+              if "${{ contains(github.event.head_commit.message, '[ci: skip-doc]') }}" == "true" or "ubuntu-latest" not in build:
+                  build_doc = "false"
+          oses = ["macos", "ubuntu", "windows"]
+          build_dict = {os : [k for k in build if k.startswith(os)] for os in oses}
+          print(f"::set-output name=build::{build_dict}")
+          print(f"::set-output name=test::{dict({os : [k for k in test if k.startswith(os)] for os in oses})}")
+          print(f"::set-output name=build_doc::{build_doc}")
+          for os in oses:
+              print(f"::set-output name=do_{os}::{'true' if len(build_dict[os]) > 0 else 'false'}")
           print(f"::set-output name=python_version::{python_version}")
-          print(f"::set-output name=build::{build}")
-          print(f"::set-output name=test::{test}")
 
   lint-sources:
     runs-on: ubuntu-latest
@@ -49,8 +94,8 @@ jobs:
       - uses: pre-commit/action@v2.0.0
 
   build-windows:
-    needs:
-      - setup
+    needs: [setup]
+    if: needs.setup.outputs.do_windows == 'true'
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).windows }}
@@ -128,8 +173,8 @@ jobs:
           path: dist/*.whl
 
   build-macos:
-    needs:
-      - setup
+    needs: [setup]
+    if: needs.setup.outputs.do_macos == 'true'
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).macos }}
@@ -220,12 +265,12 @@ jobs:
           name: wheels
           path: dist/*.whl
 
-  build-linux:
-    needs:
-      - setup
+  build-ubuntu:
+    needs: [setup]
+    if: needs.setup.outputs.do_ubuntu == 'true'
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.setup.outputs.build).linux }}
+        os: ${{ fromJSON(needs.setup.outputs.build).ubuntu }}
         python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
       fail-fast: false
     defaults:
@@ -326,9 +371,7 @@ jobs:
           path: dist/*.whl
 
   test-windows:
-    needs:
-      - build-windows
-      - setup
+    needs: [build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).windows }}
@@ -366,9 +409,7 @@ jobs:
           pytest -v -s tests/scheduling
 
   test-macos:
-    needs:
-      - build-macos
-      - setup
+    needs: [build-macos, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).macos }}
@@ -406,13 +447,11 @@ jobs:
           pytest -v -s tests/solvers/python
           pytest -v -s tests/scheduling
 
-  test-linux:
-    needs:
-      - build-linux
-      - setup
+  test-ubuntu:
+    needs: [build-ubuntu, setup]
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.setup.outputs.test).linux }}
+        os: ${{ fromJSON(needs.setup.outputs.test).ubuntu }}
         python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -443,8 +482,9 @@ jobs:
           pytest -v -s tests/solvers/python
           pytest -v -s tests/scheduling
 
-  build-docs:
-    needs: [test-linux, test-macos, test-windows]
+  build-doc:
+    needs: [test-ubuntu, setup]
+    if: needs.setup.outputs.build_doc == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -515,9 +555,38 @@ jobs:
           clean-exclude: |
             "version/*"
 
+  upload-doc:
+    needs: [build-doc, test-windows, test-macos]
+    if: github.ref == 'refs/heads/master'
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7"]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v1.0.0
+        with:
+          name: doc
+          path: docs/.vuepress/dist
+
+      - name: Deploy documentation in root folder on GH pages 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/.vuepress/dist # The folder the action should deploy.
+          target-folder: / # The folder the action should deploy to.
+          commit-message: publish documentation
+          clean-exclude: |
+            "version/*"
+
   upload-nightly:
     if: (github.ref == 'refs/heads/master') && (github.repository == 'airbus/scikit-decide') && (github.event_name == 'schedule')
-    needs: [test-linux, test-macos, test-windows]
+    needs: [test-ubuntu, test-macos, test-windows]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       python_version: ${{ steps.generate-matrix.outputs.python_version }}
       build: ${{ steps.generate-matrix.outputs.build}}
       test: ${{ steps.generate-matrix.outputs.test}}
+      deploy_test_pypi: ${{ steps.generate-matrix.outputs.deploy_test_pypi}}
     steps:
       - uses: actions/setup-python@v2
       - name: Generate Matrix
@@ -25,11 +26,17 @@ jobs:
         shell: python3 {0}
         run: |
           python_version = ["3.7", "3.8", "3.9"]
-          build = { "macos": ["macos-10.15"], "linux": ["ubuntu-latest"], "windows": ["windows-2016"] }
-          test = { "macos": ["macos-10.15", "macos-11"], "linux": ["ubuntu-18.04", "ubuntu-20.04"], "windows": ["windows-2016", "windows-2019", "windows-2022"] }
+          build_dict = { "macos":["macos-10.15"], "ubuntu":["ubuntu-latest"], "windows":["windows-2016"] }
+          test_dict = { "macos":["macos-10.15", "macos-11"], "ubuntu":["ubuntu-18.04", "ubuntu-20.04"], "windows":["windows-2016", "windows-2019", "windows-2022" ]}
+          deploy_test_pypi = "true"
+
+          if "${{ contains(github.event.head_commit.message, '[ci: skip-deploy-test-pypi]') }}" == "true":
+              deploy_test_pypi = "false"
+
+          print(f"::set-output name=build::{build_dict}")
+          print(f"::set-output name=test::{test_dict}")
           print(f"::set-output name=python_version::{python_version}")
-          print(f"::set-output name=build::{build}")
-          print(f"::set-output name=test::{test}")
+          print(f"::set-output name=deploy_test_pypi::{deploy_test_pypi}")
 
   lint-sources:
     runs-on: ubuntu-latest
@@ -41,8 +48,7 @@ jobs:
       - uses: pre-commit/action@v2.0.0
 
   build-windows:
-    needs:
-      - setup
+    needs: [setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).windows }}
@@ -120,8 +126,7 @@ jobs:
           path: dist/*.whl
 
   build-macos:
-    needs:
-      - setup
+    needs: [setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).macos }}
@@ -201,12 +206,11 @@ jobs:
           name: wheels
           path: dist/*.whl
 
-  build-linux:
-    needs:
-      - setup
+  build-ubuntu:
+    needs: [setup]
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.setup.outputs.build).linux }}
+        os: ${{ fromJSON(needs.setup.outputs.build).ubuntu }}
         python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
       fail-fast: false
     defaults:
@@ -295,9 +299,7 @@ jobs:
           path: dist/*.whl
 
   test-windows:
-    needs:
-      - build-windows
-      - setup
+    needs: [build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).windows }}
@@ -335,9 +337,7 @@ jobs:
           pytest -v -s tests/scheduling
 
   test-macos:
-    needs:
-      - build-macos
-      - setup
+    needs: [build-macos, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).macos }}
@@ -375,13 +375,11 @@ jobs:
           pytest -v -s tests/solvers/python
           pytest -v -s tests/scheduling
 
-  test-linux:
-    needs:
-      - build-linux
-      - setup
+  test-ubuntu:
+    needs: [build-ubuntu, setup]
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.setup.outputs.test).linux }}
+        os: ${{ fromJSON(needs.setup.outputs.test).ubuntu }}
         python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -413,7 +411,7 @@ jobs:
           pytest -v -s tests/scheduling
 
   upload:
-    needs: [test-linux, test-macos, test-windows]
+    needs: [test-ubuntu, test-macos, test-windows]
     runs-on: ubuntu-latest
 
     steps:
@@ -437,7 +435,7 @@ jobs:
           file_glob: true
 
   deploy:
-    needs: [upload]
+    needs: [upload, setup]
     runs-on: ubuntu-latest
 
     steps:
@@ -458,14 +456,14 @@ jobs:
       - name: Publish distribution 📦 to Test PyPI
         env:
           TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_PASSWORD }}
-        if: env.TEST_PYPI_TOKEN != ''
+        if: env.TEST_PYPI_TOKEN != '' && needs.setup.outputs.deploy_test_pypi == 'true'
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.TEST_PYPI_PASSWORD }}
           packages_dir: wheels/
           repository_url: https://test.pypi.org/legacy/
 
-  build-docs:
+  build-doc:
     needs: [deploy]
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
By using specific keywords the user can interact on the ci build and release workflows
For `build` the following keywords are available:
- By default, built are done on the oldest versions of the oses
- [ci: os-version] will keep the specific version of the  given os (if version is omitted all versions will be kept),
- [skip-doc] will skip the doc generation

For `release`, only one keyword is available:
- [ci: skip-deploy-test-pypi] will skip the deployment of the wheels on Test PyPI