### PR TITLE
Fix missing parenthesis in notebooks commented code

### DIFF
--- a/notebooks/11_maze_tuto.ipynb
+++ b/notebooks/11_maze_tuto.ipynb
@@ -554,7 +554,7 @@
     "```python\n",
     "with solver_factory() as solver:\n",
     "    MyDomain.solve_with(solver, domain_factory)\n",
-    "    rollout(domain=domain, solver=solver\n",
+    "    rollout(domain=domain, solver=solver)\n",
     "```"
    ]
   },

--- a/notebooks/12_gym_tuto.ipynb
+++ b/notebooks/12_gym_tuto.ipynb
@@ -403,7 +403,7 @@
     "```python\n",
     "with solver_factory() as solver:\n",
     "    MyDomain.solve_with(solver, domain_factory)\n",
-    "    rollout(domain=domain, solver=solver\n",
+    "    rollout(domain=domain, solver=solver)\n",
     "```"
    ]
   },


### PR DESCRIPTION
In a comment, we show how to solve the domain inside
a `with` block. The code was broken because of a missing ).