### PR TITLE
Removing need for GH_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,7 +551,6 @@ jobs:
       - name: Delete nightly release
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.gh_access_token }}
           script: |
             const releases = await github.rest.repos.listReleases({
               owner: context.repo.owner,


### PR DESCRIPTION
The token was not in the secrets which causes this job to break.
The secret is not referenced anymore