### PR TITLE
Bump scikit-decide to 0.9.4 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     - matplotlib
     - ipywidgets
     - ipympl
-    - scikit-decide[all]==0.9.2
+    - scikit-decide[all]==0.9.4
     - nbgitpuller
     - pyvirtualdisplay
     - PyOpenGL-accelerate


### PR DESCRIPTION
Notebooks on https://airbus.github.io/scikit-decide/notebooks/ use this binder branch, we want to use scikit-decide 0.9.4 and not 0.9.2.