### PR TITLE
Install torch with cpuonly from pytorch channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,12 @@
 name: nb-skdecide092-py38
+channels:
+  - pytorch
+  - defaults
 dependencies:
   - python=3.8
   - pip
+  - pytorch::cpuonly
+  - pytorch::pytorch
   - pip:
     - matplotlib
     - ipywidgets


### PR DESCRIPTION
This version is 200MB instead of 900MB, and binders do not have GPUs.