### PR TITLE
Optimize scheduling domains code

### DIFF
--- a/examples/scheduling/computation_time_experiments.py
+++ b/examples/scheduling/computation_time_experiments.py
@@ -1,0 +1,91 @@
+import time
+
+from examples.discrete_optimization.rcpsp_multiskill_parser_example import (
+    get_complete_path_ms,
+    get_data_available_ms,
+)
+from examples.discrete_optimization.rcpsp_parser_example import (
+    get_complete_path,
+    get_data_available,
+)
+from skdecide import DiscreteDistribution, rollout_episode
+from skdecide.builders.domain.scheduling.scheduling_domains_modelling import (
+    SchedulingAction,
+    SchedulingActionEnum,
+    State,
+)
+from skdecide.hub.domain.rcpsp.rcpsp_sk import MSRCPSP, RCPSP
+from skdecide.hub.domain.rcpsp.rcpsp_sk_parser import (
+    load_domain,
+    load_multiskill_domain,
+)
+from skdecide.hub.solver.do_solver.do_solver_scheduling import DOSolver, SolvingMethod
+from skdecide.hub.solver.sgs_policies.sgs_policies import (
+    BasePolicyMethod,
+    PolicyMethodParams,
+)
+
+
+def do_rollout_comparaison(domain: RCPSP, solver, inplace: bool = True):
+    domain.set_inplace_environment(inplace)
+    tic = time.perf_counter()
+    states, actions, values = rollout_episode(
+        domain=domain,
+        solver=solver,
+        from_memory=domain.get_initial_state(),
+        max_steps=1000,
+        outcome_formatter=None,
+        action_formatter=None,
+        verbose=False,
+    )
+    toc = time.perf_counter()
+    print(
+        f"{toc - tic:0.4f} seconds to rollout policy with inplace={inplace} environment, "
+        f"Final time of the schedule : "
+        f"{states[-1].t}"
+    )
+    return states
+
+
+def run_expe():
+    do_solver = SolvingMethod.PILE  # Greedy solver.
+    domain: RCPSP = load_domain(get_complete_path("j1201_1.sm"))
+    solver = DOSolver(
+        policy_method_params=PolicyMethodParams(
+            base_policy_method=BasePolicyMethod.FOLLOW_GANTT,
+            # policy will just follow the output gantt of the greedy solver
+            delta_index_freedom=0,
+            delta_time_freedom=0,
+        ),
+        method=do_solver,
+    )
+    solver.solve(domain_factory=lambda: domain)
+    states_deepcopy = do_rollout_comparaison(domain, solver, False)
+    states_inplace = do_rollout_comparaison(domain, solver, True)
+
+    # main difference is that in the inplace environment, the object are overwritten as you can see
+    print([id(s) for s in states_inplace])
+    # Where as the deepcopy solution is creating each time a new object :
+    print([id(s) for s in states_deepcopy])
+
+    # There is a 20 factor speedup, and it's even more when the makespan is large, let's try :
+    domain: RCPSP = load_domain(get_complete_path("j1201_1.sm"))
+    for task in domain.duration_dict:
+        for mode in domain.duration_dict[task]:
+            domain.duration_dict[task][mode] *= 20
+    domain.set_inplace_environment(False)
+    solver = DOSolver(
+        policy_method_params=PolicyMethodParams(
+            base_policy_method=BasePolicyMethod.FOLLOW_GANTT,
+            delta_index_freedom=0,
+            delta_time_freedom=0,
+        ),
+        method=do_solver,
+    )
+    solver.solve(domain_factory=lambda: domain)
+    states_deepcopy = do_rollout_comparaison(domain, solver, False)
+    states_inplace = do_rollout_comparaison(domain, solver, True)
+
+
+if __name__ == "__main__":
+    run_expe()

--- a/skdecide/builders/domain/scheduling/precedence.py
+++ b/skdecide/builders/domain/scheduling/precedence.py
@@ -64,10 +64,11 @@ class WithPrecedence:
         return Graph(nodes, edges, False)
 
     def _task_modes_possible_to_launch(self, state: State):
+        mode_details = self.get_tasks_modes()
         return [
             (n, mode)
             for n in state.tasks_remaining
-            for mode in self.get_task_modes(n).keys()
+            for mode in mode_details[n]
             if all(m in state.tasks_complete for m in self.ancestors[n])
         ]
 

--- a/skdecide/builders/domain/scheduling/resource_costs.py
+++ b/skdecide/builders/domain/scheduling/resource_costs.py
@@ -43,10 +43,8 @@ class WithoutModeCosts(WithModeCosts):
 
     def _get_mode_costs(self) -> Dict[int, Dict[int, float]]:
         cost_dict = {}
-        for task_id in self.get_tasks_modes().keys():
-            cost_dict[task_id] = {}
-            for mode_id in self.get_tasks_modes()[task_id].keys():
-                cost_dict[task_id][mode_id] = 0.0
+        for task_id, modes in self.get_tasks_modes().items():
+            cost_dict[task_id] = {mode_id: 0.0 for mode_id in modes}
         return cost_dict
 
 

--- a/skdecide/builders/domain/scheduling/resource_renewability.py
+++ b/skdecide/builders/domain/scheduling/resource_renewability.py
@@ -35,22 +35,32 @@ class MixedRenewable:
         If this function returns False, the scheduling problem is unsolvable from this state.
         This is to cope with the use of non-renable resources that may lead to state from which a
         task will not be possible anymore."""
-        for task_id in state.tasks_remaining:
-            task_possible = True
-            for mode in self.get_task_modes(task_id).keys():
-                mode_possible = True
-                for res in self.get_resource_types_names():
-                    if not self.get_resource_renewability()[res]:
-                        need = self.get_task_modes(task_id)[mode].get_resource_need(res)
-                        avail = (
-                            state.resource_availability[res] - state.resource_used[res]
-                        )
-                        if avail - need < 0:
-                            mode_possible = False
-                            break
-                if mode_possible is True:
+        resource_types_names = self.get_resource_types_names()
+        resource_not_renewable = set(
+            res
+            for res, renewable in self.get_resource_renewability().items()
+            if res in resource_types_names and not renewable
+        )
+        modes_details = self.get_tasks_modes()
+        remaining_tasks = (
+            state.task_ids.difference(state.tasks_complete)
+            .difference(state.tasks_progress)
+            .difference(state.tasks_unsatisfiable)
+        )
+        for task_id in remaining_tasks:
+            for mode_consumption in modes_details[task_id].values():
+                for res in resource_not_renewable:
+                    need = mode_consumption.get_resource_need(res)
+                    avail = state.resource_availability[res] - state.resource_used[res]
+                    if avail - need < 0:
+                        break
+                else:
+                    # The else-clause runs if loop completes normally, which means
+                    # that we found a mode for which all resources are available, and
+                    # we can exit from the loop on modes.
                     break
-            if not mode_possible:
+            else:
+                # This task is not possible
                 return False
         return True
 

--- a/skdecide/builders/domain/scheduling/task.py
+++ b/skdecide/builders/domain/scheduling/task.py
@@ -26,17 +26,15 @@ class Task:
     mode: int
     paused: List[int]
     resumed: List[int]
-    resources: Dict[int, List["str"]]
 
-    def __init__(self, id: int):
+    def __init__(self, id: int, start: int, sampled_duration: int):
         self.id = id
-        self.start = None
+        self.start = start
         self.end = None
-        self.sampled_duration = None
+        self.sampled_duration = sampled_duration
         self.mode = None
         self.paused = []
         self.resumed = []
-        self.resources = {}
 
     def get_task_active_time(self, t: Optional[int] = None):
         tt = t

--- a/skdecide/hub/solver/do_solver/sk_to_do_binding.py
+++ b/skdecide/hub/solver/do_solver/sk_to_do_binding.py
@@ -44,11 +44,8 @@ def from_last_state_to_solution(state: State, domain: SchedulingDomain):
     modes = [state.tasks_mode.get(j, 1) for j in sorted(domain.get_tasks_ids())]
     modes = modes[1:-1]
     schedule = {
-        j: {
-            "start_time": state.tasks_details[j].start,
-            "end_time": state.tasks_details[j].end,
-        }
-        for j in state.tasks_details
+        p.value.id: {"start_time": p.value.start, "end_time": p.value.end}
+        for p in state.tasks_complete_details
     }
     return RCPSPSolution(
         problem=build_do_domain(domain),

--- a/skdecide/hub/solver/gphh/gphh.py
+++ b/skdecide/hub/solver/gphh/gphh.py
@@ -22,6 +22,8 @@ from skdecide.builders.domain.scheduling.scheduling_domains import D, Scheduling
 from skdecide.builders.domain.scheduling.scheduling_domains_modelling import (
     SchedulingAction,
     State,
+    rebuild_all_tasks_dict,
+    rebuild_tasks_complete_details_dict,
 )
 from skdecide.builders.solver.policy import DeterministicPolicies
 from skdecide.discrete_optimization.rcpsp.rcpsp_model import RCPSPSolution
@@ -94,9 +96,7 @@ def get_resource_requirements_across_duration(
         for res in mode_consumption.get_ressource_names():
             tmp = 0
             for t in range(duration):
-                need = domain.get_task_modes(task_id)[1].get_resource_need_at_time(
-                    res, t
-                )
+                need = mode_consumption.get_resource_need_at_time(res, t)
                 total = domain.sample_quantity_resource(res, t)
                 tmp += need / total
             values.append(tmp / duration)
@@ -873,10 +873,11 @@ class GPHHPolicy(DeterministicPolicies):
 
         if run_sgs:
             scheduled_tasks_start_times = {}
-            for j in observation.tasks_details.keys():
-                if observation.tasks_details[j].start is not None:
-                    scheduled_tasks_start_times[j] = observation.tasks_details[j].start
-                    do_model.mode_details[j][1]["duration"] = observation.tasks_details[
+            tasks_details = rebuild_all_tasks_dict(observation)
+            for j in tasks_details:
+                if tasks_details[j].start is not None:
+                    scheduled_tasks_start_times[j] = tasks_details[j].start
+                    do_model.mode_details[j][1]["duration"] = tasks_details[
                         j
                     ].sampled_duration
 
@@ -941,12 +942,10 @@ class GPHHPolicy(DeterministicPolicies):
                 rcpsp_permutation=normalized_values_for_do,
                 rcpsp_modes=modes,
             )
-
+            tasks_complete_dict = rebuild_tasks_complete_details_dict(observation)
             solution.generate_schedule_from_permutation_serial_sgs_2(
                 current_t=t,
-                completed_tasks={
-                    j: observation.tasks_details[j] for j in observation.tasks_complete
-                },
+                completed_tasks=tasks_complete_dict,
                 scheduled_tasks_start_times=scheduled_tasks_start_times,
             )
 
@@ -1020,10 +1019,11 @@ class PooledGPHHPolicy(DeterministicPolicies):
 
         if run_sgs:
             scheduled_tasks_start_times = {}
-            for j in observation.tasks_details.keys():
-                if observation.tasks_details[j].start is not None:
-                    scheduled_tasks_start_times[j] = observation.tasks_details[j].start
-                    do_model.mode_details[j][1]["duration"] = observation.tasks_details[
+            tasks_details = rebuild_all_tasks_dict(observation)
+            for j in tasks_details:
+                if tasks_details[j].start is not None:
+                    scheduled_tasks_start_times[j] = tasks_details[j].start
+                    do_model.mode_details[j][1]["duration"] = tasks_details[
                         j
                     ].sampled_duration
 
@@ -1113,12 +1113,10 @@ class PooledGPHHPolicy(DeterministicPolicies):
                 rcpsp_permutation=normalized_values_for_do,
                 rcpsp_modes=modes,
             )
-
+            tasks_complete_dict = rebuild_tasks_complete_details_dict(observation)
             solution.generate_schedule_from_permutation_serial_sgs_2(
                 current_t=t,
-                completed_tasks={
-                    j: observation.tasks_details[j] for j in observation.tasks_complete
-                },
+                completed_tasks=tasks_complete_dict,
                 scheduled_tasks_start_times=scheduled_tasks_start_times,
             )
 
@@ -1173,10 +1171,11 @@ class FixedPermutationPolicy(DeterministicPolicies):
 
         if run_sgs:
             scheduled_tasks_start_times = {}
-            for j in observation.tasks_details.keys():
-                if observation.tasks_details[j].start is not None:
-                    scheduled_tasks_start_times[j] = observation.tasks_details[j].start
-                    do_model.mode_details[j][1]["duration"] = observation.tasks_details[
+            tasks_details = rebuild_all_tasks_dict(observation)
+            for j in tasks_details.keys():
+                if tasks_details[j].start is not None:
+                    scheduled_tasks_start_times[j] = tasks_details[j].start
+                    do_model.mode_details[j][1]["duration"] = tasks_details[
                         j
                     ].sampled_duration
 
@@ -1221,12 +1220,10 @@ class FixedPermutationPolicy(DeterministicPolicies):
                 rcpsp_permutation=normalized_values_for_do,
                 rcpsp_modes=modes,
             )
-
+            tasks_details_complete = rebuild_tasks_complete_details_dict(observation)
             solution.generate_schedule_from_permutation_serial_sgs_2(
                 current_t=t,
-                completed_tasks={
-                    j: observation.tasks_details[j] for j in observation.tasks_complete
-                },
+                completed_tasks=tasks_details_complete,
                 scheduled_tasks_start_times=scheduled_tasks_start_times,
             )
 

--- a/skdecide/hub/solver/sgs_policies/sgs_policies.py
+++ b/skdecide/hub/solver/sgs_policies/sgs_policies.py
@@ -168,11 +168,12 @@ def next_action_sgs_first_task_precedence_ready(
     possible_task_to_launch = policy_rcpsp.domain.task_possible_to_launch_precedence(
         state=state
     )
+    tasks_remaining = set(state.tasks_remaining)
     sorted_task_not_done = sorted(
         [
             (index, policy_rcpsp.permutation_task[index])
             for index in range(len(policy_rcpsp.permutation_task))
-            if policy_rcpsp.permutation_task[index] in state.tasks_remaining
+            if policy_rcpsp.permutation_task[index] in tasks_remaining
         ],
         key=lambda x: x[0],
     )
@@ -248,11 +249,12 @@ def next_action_sgs_first_task_ready(
 ):
     obs: State = state
     t = obs.t
+    tasks_remaining = set(state.tasks_remaining)
     sorted_task_not_done = sorted(
         [
             (index, policy_rcpsp.permutation_task[index])
             for index in range(len(policy_rcpsp.permutation_task))
-            if policy_rcpsp.permutation_task[index] in state.tasks_remaining
+            if policy_rcpsp.permutation_task[index] in tasks_remaining
         ],
         key=lambda x: x[0],
     )
@@ -302,11 +304,12 @@ def next_action_sgs_strict(
     possible_task_to_launch = policy_rcpsp.domain.task_possible_to_launch_precedence(
         state=state
     )
+    tasks_remaining = set(state.tasks_remaining)
     sorted_task_not_done = sorted(
         [
             (index, policy_rcpsp.permutation_task[index])
             for index in range(len(policy_rcpsp.permutation_task))
-            if policy_rcpsp.permutation_task[index] in state.tasks_remaining
+            if policy_rcpsp.permutation_task[index] in tasks_remaining
             and policy_rcpsp.permutation_task[index] in possible_task_to_launch
         ],
         key=lambda x: x[0],
@@ -366,11 +369,12 @@ def next_action_sgs_time_freedom(
     possible_task_to_launch = policy_rcpsp.domain.task_possible_to_launch_precedence(
         state=state
     )
+    tasks_remaining = set(state.tasks_remaining)
     sorted_task_not_done = sorted(
         [
             (index, policy_rcpsp.permutation_task[index])
             for index in range(len(policy_rcpsp.permutation_task))
-            if policy_rcpsp.permutation_task[index] in state.tasks_remaining
+            if policy_rcpsp.permutation_task[index] in tasks_remaining
             and policy_rcpsp.permutation_task[index] in possible_task_to_launch
         ],
         key=lambda x: x[0],
@@ -432,11 +436,12 @@ def next_action_sgs_index_freedom(
     possible_task_to_launch = policy_rcpsp.domain.task_possible_to_launch_precedence(
         state=state
     )
+    tasks_remaining = set(state.tasks_remaining)
     sorted_task_not_done = sorted(
         [
             (index, policy_rcpsp.permutation_task[index])
             for index in range(len(policy_rcpsp.permutation_task))
-            if policy_rcpsp.permutation_task[index] in state.tasks_remaining
+            if policy_rcpsp.permutation_task[index] in tasks_remaining
             and policy_rcpsp.permutation_task[index] in possible_task_to_launch
         ],
         key=lambda x: x[0],

--- a/tests/scheduling/test_scheduling.py
+++ b/tests/scheduling/test_scheduling.py
@@ -56,6 +56,11 @@ optimal_solutions = {
 }
 
 
+@pytest.fixture
+def random_seed():
+    random.seed(0)
+
+
 class ToyRCPSPDomain(SingleModeRCPSP):
     def _get_objectives(self) -> List[SchedulingObjectiveEnum]:
         return [SchedulingObjectiveEnum.MAKESPAN]
@@ -471,7 +476,7 @@ class ToySimulatedCondSRCPSPDomain(
         (ToySimulatedCondSRCPSPDomain()),
     ],
 )
-def test_rollout(domain):
+def test_rollout(domain, random_seed):
     state = domain.get_initial_state()
     states, actions, values = rollout_episode(
         domain=domain,
@@ -546,7 +551,6 @@ def check_resource_constraints(domain, states: List[State]):
         tasks_complete_dict = rebuild_tasks_complete_details_dict(states[-1])
         tasks_modes_dict = rebuild_tasks_modes_dict(states[-1])
         for t in range(states[-1].t):
-
             for res in domain.get_resource_types_names():
                 total_available = domain.get_quantity_resource(res, t)
                 total_consumed = 0


### PR DESCRIPTION
We use an example (added in first commit) to try to improve scheduling domain code.

The main idea is to reduce time passed in copying the state,
by modifying the way the information on tasks is stored.

More precisely, this is the list of modifications done:

- Remove resources (unused) from tasks_details
- Lazy initialization of tasks_details
- Initialize start and sample_duration in Task constructor
- Store in state information on completed tasks in separate attributes as
  singly linked lists, since they will not be changed anymore:
  tasks_complete_details, tasks_complete_progress and tasks_complete_mode.
  Indeed singly linked lists can avoid duplication of tasks_details,
  tasks_progress and tasks_mode:
    * when a Task is inserted, it becomes the new head node and points to
      the previous head
    * in State.copy, a new singly linkedlist is created, but with the
      same head as previous state.  Both lists have the same nodes, but
      nodes inserted after can be different.

  The only drawback is that lookup is now O(N)

- Remove State.tasks_remaining.
  This set is heavy and makes State.copy() slow.
  State contains the following attributes (among others):
    * task_ids: a list of all task ids in the scheduling domain
    * tasks_remaining: a set containing the ids of tasks still to be started
    * tasks_complete: a set containing the ids of tasks that have been
          completed
    * tasks_ongoing: a set containing the ids of tasks started and not
          paused and still to be completed
    * tasks_paused: a set containing the ids of tasks that have been started
          and paused but not resumed yet
    * tasks_progress: a dictionary where the key is a task id (int) and
          the value the progress of the task between 0 and 1 (float)
  Remark: keys(tasks_progress) = tasks_ongoing + tasks_paused

  The idea behind tasks_remaining is that some tasks may require
  conditions which are not fulfilled, so tasks_remaining is a subset of
  task_ids which contains tasks which can be started.

  But at the beginning of simulation, this set may be large, and is copied
  into all State instances.  We replace this member by
    * tasks_unsatisfiable: a set containing the ids of tasks for which
          conditions are not fulfilled

  We can use tasks_unsatisfiable to compute tasks_remaining by:

     task_ids - tasks_complete - tasks_progress - tasks_unsatisfiable

  Copy of tasks_unsatisfiable will be much faster than tasks_remaining,
  but the extra computations may cancel this gain, the overall speedup
  (if any) must be confirmed on real cases.

- Speedup MixedRenewable.all_tasks_possible() buy moving creation of
  dicts and sets outside of loops.
- Do not call get_task_modes() in loops