### PR TITLE
Fix minizinc configuration

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -75,10 +75,11 @@ Here are the steps to follow:
         poetry env use 3.8.11
         ```
 
-    - Install all dependencies as defined in `poetry.lock`.
+    - Install all dependencies as defined in `poetry.lock`, build c++ libraries, and configure them.
         ```shell
         rm -rf build  # removing previous build
         poetry install --extras all
+        poetry run python postbuild_dev.py
         ```
 
 #### Alternate installation with conda + poetry
@@ -107,10 +108,11 @@ as it can also be installed by conda via the conda-forge channel.
     conda install -c conda-forge poetry
     ```
 
-- Install all dependencies as defined in `poetry.lock`.
+- Install all dependencies as defined in `poetry.lock`, build c++ libraries, and configure them.
     ```shell
     rm -rf build  # removing previous build
     poetry install --extras all
+    poetry run python postbuild_dev.py
     ```
 
 #### Use of developer mode installation

--- a/postbuild_dev.py
+++ b/postbuild_dev.py
@@ -1,0 +1,45 @@
+"""Post-build script to be run to setup developer environment.
+
+After `poetry install`, some further steps are required to have the poetry environment working properly,
+similarly to a normal install from pypi.
+
+Currently, this steps are:
+- finish minizinc setup: the embedded minizinc needs the gecode.msc configuration file
+  to be placed near the corresponding executables and libraries (as paths within are relative to it)
+
+"""
+
+import os
+import shutil
+
+from setuptools import setup
+from setuptools.command.build_ext import build_ext
+from setuptools.extension import Extension
+
+
+def configure_minizinc():
+    print("Finish minizinc configuration")
+
+    class ExtensionBuilder(build_ext):
+        def run(self):
+            print(f"Copying gecode.msc to {self.build_lib} directory")
+            root_dir = os.path.dirname(os.path.abspath(__file__))
+            skdecidehub_relativepath = "skdecide/hub"
+            gecodeconfig_filename = "gecode.msc"
+            gecodeconfig_retativepath = (
+                f"{skdecidehub_relativepath}/{gecodeconfig_filename}"
+            )
+            srcfile = f"{root_dir}/{gecodeconfig_retativepath}"
+            detsfile = f"{root_dir}/{self.build_lib}/{gecodeconfig_retativepath}"
+            shutil.copyfile(srcfile, detsfile)
+
+    setup(
+        cmdclass=dict(build_ext=ExtensionBuilder),
+        ext_modules=[Extension(name="", sources=[""])],
+        zip_safe=False,
+        script_args=["build"],
+    )
+
+
+if __name__ == "__main__":
+    configure_minizinc()

--- a/skdecide/hub/__init__.py
+++ b/skdecide/hub/__init__.py
@@ -10,14 +10,40 @@ import sys
 from ctypes.util import find_library
 from pathlib import Path
 
-pl = []
-
-for p in sys.path:
-    for dirpath, dirs, files in os.walk(p):
-        for filename in fnmatch.filter(files, "__skdecide_hub_cpp*"):
-            pl.append(dirpath)
-            pl.append(os.path.join(dirpath, "bin"))
-            os.environ["MZN_SOLVER_PATH"] = dirpath
+# minizinc setup:
+#  - add embedded minizinc and related solvers binaries to PATH (last position)
+#  - find solver definitions *.msc directories and set MZN_SOLVER_PATH
+dirpath = __path__[0]
+mzn_solver_paths = ""
+mzn_bin_path = ""
 
 
-os.environ["PATH"] += os.pathsep + os.pathsep.join(pl)
+def _contains_minizinc_bin_directory(dirpath):
+    return os.path.exists(f"{dirpath}/bin/minizinc") or os.path.exists(
+        f"{dirpath}/bin/minizinc.exe"
+    )
+
+
+if _contains_minizinc_bin_directory(dirpath):
+    # release install via pip
+    mzn_solver_path = dirpath
+    mzn_bin_path = f"{dirpath}/bin"
+else:
+    # dev install via poetry: find skdecide/hub in build directory, only one instance
+    break_loop = False
+    for p in sys.path:
+        if break_loop:
+            break
+        for dirpath, dirs, files in os.walk(p):
+            if len(
+                fnmatch.filter(files, "__skdecide_hub_cpp*")
+            ) > 0 and _contains_minizinc_bin_directory(dirpath):
+                mzn_solver_path = dirpath
+                mzn_bin_path = f"{dirpath}/bin"
+                break_loop = True
+                break
+# set path and mzn solver path
+if mzn_bin_path:
+    os.environ["PATH"] += os.pathsep + mzn_bin_path
+if mzn_solver_path:
+    os.environ["MZN_SOLVER_PATH"] = mzn_solver_path


### PR DESCRIPTION
When importing `skdecide.hub`, the path to minizinc binaries and to
solvers definition is updated with embedded versions of minizinc.

This worked great with install from releases but was not working when
using poetry, because paths are different.
Another issue was that more paths than needed were potentially added.

For release install, it is actually sufficient to look at directory
containing `skdecide.hub.__init__.py` as it should contain the solvers
configuration files *.msc and the bin/ directory with minizinc (and
the C++ library` __skdecide_hub_cpp`)

For poetry, this directory is still needed to find gecode.msc, but the
other solver configurations and the bin/ directory with minizinc are in the
build directory generated by `poetry install`, together with the C++
library  `__skdecide_hub_cpp`, which is used to find the proper directory.

NB:
- in release install case, if `import skdecide.hub` is done when
  working directory is the project directory where a poetry install has
  been done, it can result by pointing to the minizinc built by poetry
  (but anyway it will also be the code from the repository that will be
  used for skdecide instead of the one installed via pip)
- if several poetry installs have been made (with various version of
  python for instance), we do not ensure that the minizinc chosen will
  be that of the current poetry environment.