### PR TITLE
Rewrite extender to return a list

### DIFF
--- a/skdecide/hub/solver/lazy_astar/lazy_astar.py
+++ b/skdecide/hub/solver/lazy_astar/lazy_astar.py
@@ -65,14 +65,18 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities):
         self._domain = domain_factory()
 
         def extender(node, label, explored):
+            result = []
             for a in self._domain.get_applicable_actions(node).get_elements():
                 n = self._domain.get_next_state(node, a)
                 if n not in explored:
-                    yield (
-                        n,
-                        self._domain.get_transition_value(node, a, n).cost,
-                        {"action": a},
+                    result.append(
+                        (
+                            n,
+                            self._domain.get_transition_value(node, a, n).cost,
+                            {"action": a},
+                        )
                     )
+            return result
 
         push = heappush
         pop = heappop


### PR DESCRIPTION
We revert commit 9df73f72ebc05c8242e1cfb782e6b96855702af8 because
returning a generator may lead to errors hard to understand when the
domain developper do not take properly into account how "yield" works,
for instance if using global variables.

But we still modify how the list is computed to avoid using 2
intermediate lists (which allow to gain 1.1 speed factor on a
given graph shortest path example).