### PR TITLE
Fix bug in lint-sources job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: ["--autofix", "--no-sort-keys", "--indent", "4"]
 
   - repo: https://github.com/psf/black
-    rev: 21.7b0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 22.3.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3

--- a/builder.py
+++ b/builder.py
@@ -102,7 +102,7 @@ class ExtensionBuilder(build_ext):
         build_args = ["--config", ext.cmake_build_type]
 
         if platform.system() == "Windows":
-            if sys.maxsize > 2 ** 32:
+            if sys.maxsize > 2**32:
                 configure_args += ["-A", "x64"]
             build_args += ["--", "/m"]
         else:

--- a/skdecide/discrete_optimization/generic_tools/lns_cp.py
+++ b/skdecide/discrete_optimization/generic_tools/lns_cp.py
@@ -77,7 +77,7 @@ class LNS_CP(SolverDO):
         nb_iteration_no_improvement: Optional[int] = None,
         max_time_seconds: Optional[int] = None,
         skip_first_iteration: bool = False,
-        **args
+        **args,
     ) -> ResultStorage:
         sense = self.params_objective_function.sense_function
         if max_time_seconds is None:

--- a/skdecide/discrete_optimization/generic_tools/lns_mip.py
+++ b/skdecide/discrete_optimization/generic_tools/lns_mip.py
@@ -94,7 +94,7 @@ class LNS_MILP(SolverDO):
         nb_iteration_no_improvement: Optional[int] = None,
         max_time_seconds: Optional[int] = None,
         skip_first_iteration: Optional[bool] = False,
-        **args
+        **args,
     ) -> ResultStorage:
         sense = self.params_objective_function.sense_function
         if max_time_seconds is None:

--- a/skdecide/discrete_optimization/rcpsp/solver/calendar_solver_iterative.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/calendar_solver_iterative.py
@@ -398,7 +398,7 @@ class SolverWithCalendarIterative(SolverDO):
         self,
         problem_calendar: RCPSPModelCalendar,
         partial_solution: PartialSolution = None,
-        **kwargs
+        **kwargs,
     ):
         self.problem_calendar = problem_calendar
         if not isinstance(problem_calendar, RCPSPModelCalendar):
@@ -479,7 +479,7 @@ class SolverWithCalendarIterative(SolverDO):
         nb_iteration_no_improvement: Optional[int] = None,
         max_time_seconds: Optional[int] = None,
         skip_first_iteration: bool = False,
-        **args
+        **args,
     ) -> ResultStorage:
 
         sense = self.params_objective_function.sense_function

--- a/skdecide/discrete_optimization/rcpsp/solver/cp_solvers.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/cp_solvers.py
@@ -71,7 +71,7 @@ class CP_RCPSP_MZN(CPSolver):
         rcpsp_model: RCPSPModel,
         cp_solver_name: CPSolverName = CPSolverName.CHUFFED,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.instance: Instance = None
@@ -284,7 +284,7 @@ class CP_MRCPSP_MZN(CPSolver):
         rcpsp_model: RCPSPModel,
         cp_solver_name: CPSolverName = CPSolverName.CHUFFED,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.instance = None
@@ -613,7 +613,7 @@ class CP_MRCPSP_MZN_NOBOOL(CPSolver):
         rcpsp_model: RCPSPModel,
         cp_solver_name: CPSolverName = CPSolverName.CHUFFED,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.instance = None

--- a/skdecide/discrete_optimization/rcpsp/solver/ls_solver.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/ls_solver.py
@@ -55,7 +55,7 @@ class LS_RCPSP_Solver(SolverDO):
         model: Union[RCPSPModel, MS_RCPSPModel],
         params_objective_function: ParamsObjectiveFunction = None,
         ls_solver: LS_SOLVER = LS_SOLVER.SA,
-        **args
+        **args,
     ):
         self.model = model
         (

--- a/skdecide/discrete_optimization/rcpsp/solver/rcpsp_cp_lns_solver.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/rcpsp_cp_lns_solver.py
@@ -399,7 +399,7 @@ class LNS_CP_RCPSP_SOLVER(SolverDO):
         self,
         rcpsp_model: RCPSPModel,
         option_neighbor: OptionNeighbor = OptionNeighbor.MIX_ALL,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.solver = CP_MRCPSP_MZN(

--- a/skdecide/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/rcpsp_ga_solver.py
@@ -26,7 +26,7 @@ class GA_RCPSP_Solver(SolverDO):
         self,
         rcpsp_model: RCPSPModel,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         (
@@ -55,7 +55,7 @@ class GA_MRCPSP_Solver(SolverDO):
         self,
         rcpsp_model: MultiModeRCPSPModel,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         (

--- a/skdecide/discrete_optimization/rcpsp/solver/rcpsp_lp_solver.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/rcpsp_lp_solver.py
@@ -54,7 +54,7 @@ class LP_RCPSP(MilpSolver):
         rcpsp_model: SingleModeRCPSPModel,
         lp_solver=LP_RCPSP_Solver.CBC,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.model: Model = None
@@ -320,7 +320,7 @@ class LP_MRCPSP(MilpSolver):
         rcpsp_model: MultiModeRCPSPModel,
         lp_solver=LP_RCPSP_Solver.CBC,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.model: Model = None
@@ -620,7 +620,7 @@ class LP_MRCPSP_GUROBI(MilpSolver):
         rcpsp_model: MultiModeRCPSPModel,
         lp_solver=LP_RCPSP_Solver.CBC,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.model: gurobi.Model = None

--- a/skdecide/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/rcpsp_lp_solver_gantt.py
@@ -72,7 +72,7 @@ class LP_MRCPSP_GANTT(MilpSolver):
         rcpsp_model: RCPSPModelCalendar,
         rcpsp_solution: RCPSPSolution,
         lp_solver=MilpSolverName.CBC,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.lp_solver = lp_solver
@@ -246,7 +246,7 @@ class LP_MRCPSP_GANTT_GUROBI(MilpSolver):
         rcpsp_model: RCPSPModelCalendar,
         rcpsp_solution: RCPSPSolution,
         lp_solver=MilpSolverName.CBC,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.lp_solver = lp_solver

--- a/skdecide/discrete_optimization/rcpsp/solver/rcpsp_pile.py
+++ b/skdecide/discrete_optimization/rcpsp/solver/rcpsp_pile.py
@@ -50,7 +50,7 @@ class PileSolverRCPSP(SolverDO):
         self,
         rcpsp_model: RCPSPModel,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.resources = rcpsp_model.resources
@@ -264,7 +264,7 @@ class PileSolverRCPSP_Calendar(SolverDO):
         self,
         rcpsp_model: RCPSPModelCalendar,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.resources = rcpsp_model.resources

--- a/skdecide/discrete_optimization/rcpsp_multiskill/solvers/calendar_solver_iterative.py
+++ b/skdecide/discrete_optimization/rcpsp_multiskill/solvers/calendar_solver_iterative.py
@@ -482,7 +482,7 @@ class SolverWithCalendarIterative(SolverDO):
         problem_calendar: MS_RCPSPModel,
         partial_solution: PartialSolution = None,
         option_neighbor: OptionNeighbor = OptionNeighbor.MIX_FAST,
-        **kwargs
+        **kwargs,
     ):
         self.problem_calendar = problem_calendar
         self.problem_no_calendar = self.problem_calendar.copy()
@@ -555,7 +555,7 @@ class SolverWithCalendarIterative(SolverDO):
         nb_iteration_no_improvement: Optional[int] = None,
         max_time_seconds: Optional[int] = None,
         skip_first_iteration: bool = False,
-        **args
+        **args,
     ) -> ResultStorage:
         sense = self.params_objective_function.sense_function
         if max_time_seconds is None:

--- a/skdecide/discrete_optimization/rcpsp_multiskill/solvers/cp_solvers.py
+++ b/skdecide/discrete_optimization/rcpsp_multiskill/solvers/cp_solvers.py
@@ -63,7 +63,7 @@ class CP_MS_MRCPSP_MZN(CPSolver):
         rcpsp_model: MS_RCPSPModel,
         cp_solver_name: CPSolverName = CPSolverName.CHUFFED,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.instance: Instance = None

--- a/skdecide/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
+++ b/skdecide/discrete_optimization/rcpsp_multiskill/solvers/lp_model.py
@@ -32,7 +32,7 @@ class LP_Solver_MRSCPSP(MilpSolver):
         rcpsp_model: MS_RCPSPModel,
         lp_solver: MilpSolverName = MilpSolverName.CBC,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.model: Model = None

--- a/skdecide/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_cp_lns_solver.py
+++ b/skdecide/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_cp_lns_solver.py
@@ -705,7 +705,7 @@ class LNS_CP_MS_RCPSP_SOLVER(SolverDO):
         self,
         rcpsp_model: MS_RCPSPModel,
         option_neighbor: OptionNeighbor = OptionNeighbor.MIX_ALL,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         self.solver = CP_MS_MRCPSP_MZN(

--- a/skdecide/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_ga_solver.py
+++ b/skdecide/discrete_optimization/rcpsp_multiskill/solvers/ms_rcpsp_ga_solver.py
@@ -19,7 +19,7 @@ class GA_MSRCPSP_Solver(SolverDO):
         self,
         rcpsp_model: MultiModeRCPSPModel,
         params_objective_function: ParamsObjectiveFunction = None,
-        **kwargs
+        **kwargs,
     ):
         self.rcpsp_model = rcpsp_model
         (

--- a/skdecide/discrete_optimization/rcpsp_multiskill/solvers/solver_rcpsp_based.py
+++ b/skdecide/discrete_optimization/rcpsp_multiskill/solvers/solver_rcpsp_based.py
@@ -29,7 +29,7 @@ class Solver_RCPSP_Based(SolverDO):
         model: Union[MS_RCPSPModel, MS_RCPSPModel_Variant],
         method,
         params_objective_function: ParamsObjectiveFunction = None,
-        **args
+        **args,
     ):
         self.model = model
         self.model_rcpsp = model.build_multimode_rcpsp_calendar_representative()

--- a/skdecide/hub/solver/aostar/aostar.py
+++ b/skdecide/hub/solver/aostar/aostar.py
@@ -125,7 +125,6 @@ try:
         def _get_utility(self, observation: D.T_agent[D.T_observation]) -> D.T_value:
             return self._solver.get_utility(observation)
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/astar/astar.py
+++ b/skdecide/hub/solver/astar/astar.py
@@ -116,7 +116,6 @@ try:
         def _get_utility(self, observation: D.T_agent[D.T_observation]) -> D.T_value:
             return self._solver.get_utility(observation)
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/bfws/bfws.py
+++ b/skdecide/hub/solver/bfws/bfws.py
@@ -129,7 +129,6 @@ try:
         def _get_utility(self, observation: D.T_agent[D.T_observation]) -> D.T_value:
             return self._solver.get_utility(observation)
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/ilaostar/ilaostar.py
+++ b/skdecide/hub/solver/ilaostar/ilaostar.py
@@ -136,7 +136,6 @@ try:
         ]:
             return self._solver.get_policy()
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/iw/iw.py
+++ b/skdecide/hub/solver/iw/iw.py
@@ -131,7 +131,6 @@ try:
         def get_intermediate_scores(self) -> List[Tuple[int, float]]:
             return self._solver.get_intermediate_scores()
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/lrtdp/lrtdp.py
+++ b/skdecide/hub/solver/lrtdp/lrtdp.py
@@ -179,7 +179,6 @@ try:
         ]:
             return self._solver.get_policy()
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/martdp/martdp.py
+++ b/skdecide/hub/solver/martdp/martdp.py
@@ -195,7 +195,6 @@ try:
         ]:
             return self._solver.get_policy()
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/mcts/mcts.py
+++ b/skdecide/hub/solver/mcts/mcts.py
@@ -423,7 +423,6 @@ try:
                 watchdog=watchdog,
             )
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/riw/riw.py
+++ b/skdecide/hub/solver/riw/riw.py
@@ -185,7 +185,6 @@ try:
         def get_action_prefix(self) -> List[D.T_agent[D.T_observation]]:
             return self._solver.get_action_prefix()
 
-
 except ImportError:
     sys.path = record_sys_path
     print(

--- a/skdecide/hub/solver/sgs_policies/sgs_policies.py
+++ b/skdecide/hub/solver/sgs_policies/sgs_policies.py
@@ -244,7 +244,7 @@ def next_action_sgs_first_task_ready(
     state: State,
     check_if_applicable: bool = False,
     domain_sk_decide: Union[MultiModeRCPSP, SingleModeRCPSP] = None,
-    **kwargs
+    **kwargs,
 ):
     obs: State = state
     t = obs.t
@@ -295,7 +295,7 @@ def next_action_sgs_strict(
     state: State,
     check_if_applicable: bool = False,
     domain_sk_decide: Union[MultiModeRCPSP, SingleModeRCPSP] = None,
-    **kwargs
+    **kwargs,
 ):
     obs: State = state
     t = obs.t
@@ -360,7 +360,7 @@ def next_action_sgs_time_freedom(
     check_if_applicable: bool = False,
     domain_sk_decide: Union[MultiModeRCPSP, SingleModeRCPSP] = None,
     delta_time_freedom: int = 10,
-    **kwargs
+    **kwargs,
 ):
     obs: State = state
     possible_task_to_launch = policy_rcpsp.domain.task_possible_to_launch_precedence(
@@ -426,7 +426,7 @@ def next_action_sgs_index_freedom(
     check_if_applicable: bool = False,
     domain_sk_decide: Union[MultiModeRCPSP, SingleModeRCPSP] = None,
     delta_index_freedom: int = 10,
-    **kwargs
+    **kwargs,
 ):
     obs: State = state
     possible_task_to_launch = policy_rcpsp.domain.task_possible_to_launch_precedence(

--- a/skdecide/hub/solver/stable_baselines/stable_baselines.py
+++ b/skdecide/hub/solver/stable_baselines/stable_baselines.py
@@ -38,7 +38,7 @@ class StableBaseline(Solver, Policies, Restorable):
         algo_class: type,
         baselines_policy: Any,
         learn_config: Dict = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         """Initialize StableBaselines.
 


### PR DESCRIPTION
The linting job in github action was crashing because of a dependency conflict. This is solved by upgrading the black version used.

See https://github.com/psf/black/issues/2964 or https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click  for more explanation.