### PR TITLE
Update pynng dependency for windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ files = ["skdecide/__init__.py"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pynng = "^0.6.2"
+pynng = ">=0.6.2"
 pathos = "^0.2.7"
 simplejson = {version = "^3.17.2", optional = true}
 gym = {version = "^0.18.0", optional = true}


### PR DESCRIPTION
There is no wheel for pynng 0.6.2 for python 3.9 on windows.
So when installing, the wheel has to be generated and it makes
crash the github workflow since 24/06/2022.

See https://github.com/airbus/scikit-decide/runs/7035048822?check_suite_focus=true