### PR TITLE
Build fails with latest 3.6 Matplotlib version

### DIFF
--- a/examples/maze_multiagent_mdp_multisolve.py
+++ b/examples/maze_multiagent_mdp_multisolve.py
@@ -377,7 +377,6 @@ class MultiAgentMaze(D):
     def _render_from(self, memory: D.T_memory[D.T_state], **kwargs: Any) -> Any:
         if self._ax is None:
             fig = plt.gcf()
-            fig.canvas.set_window_title("Maze")
             ax = plt.axes()
             ax.set_aspect("equal")  # set the x and y axes to the same scale
             plt.xticks([])  # remove the tick marks by setting to an empty list

--- a/skdecide/hub/domain/maze/maze.py
+++ b/skdecide/hub/domain/maze/maze.py
@@ -145,7 +145,6 @@ class Maze(D):
         if self._ax is None:
             # fig = plt.gcf()
             fig, ax = plt.subplots(1)
-            fig.canvas.set_window_title("Maze")
             # ax = plt.axes()
             ax.set_aspect("equal")  # set the x and y axes to the same scale
             plt.xticks([])  # remove the tick marks by setting to an empty list


### PR DESCRIPTION
The set_window_title function was deprecated in Matplotlib 3.4 and has be removed in 3.6