### PR TITLE
Replace try..except by an method existence check to ease debugging

### DIFF
--- a/skdecide/hub/solver/do_solver/do_solver_scheduling.py
+++ b/skdecide/hub/solver/do_solver/do_solver_scheduling.py
@@ -211,10 +211,8 @@ class DOSolver(Solver, DeterministicPolicies):
 
         self.solver = solver_class(self.do_domain, **self.dict_params)
 
-        try:
+        if hasattr(self.solver, "init_model") and callable(self.solver.init_model):
             self.solver.init_model(**self.dict_params)
-        except:
-            pass
 
         result_storage = self.solver.solve(**self.dict_params)
         best_solution: RCPSPSolution = result_storage.get_best_solution()


### PR DESCRIPTION
The call to init_model() was inside a try.. except block because some solver does not have such method.
We replace this block by a test wether the method exists so that an error inside the init_model() will be seen to better understand why a solve does not work as expected.