### PR TITLE
Add a tasks_full_details attribute to State for scheduling notebook

### DIFF
--- a/notebooks/13_scheduling_tuto.ipynb
+++ b/notebooks/13_scheduling_tuto.ipynb
@@ -222,7 +222,7 @@
    "outputs": [],
    "source": [
     "print(\n",
-    "    f\"{len(state.tasks_remaining)} tasks over {len(state.task_ids)} are still unscheduled\"\n",
+    "    f\"{len(set(state.tasks_remaining))} tasks over {len(state.task_ids)} are still unscheduled\"\n",
     ")"
    ]
   },
@@ -239,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"{state.tasks_details[1]}\")"
+    "print(f\"{state.tasks_full_details[1]}\")"
    ]
   },
   {
@@ -377,7 +377,7 @@
    "outputs": [],
    "source": [
     "print(\n",
-    "    f\"Time of last state: {final_state.t} - Ending time of Task #5: {final_state.tasks_details[5].end}\"\n",
+    "    f\"Time of last state: {final_state.t} - Ending time of Task #5: {final_state.tasks_full_details[5].end}\"\n",
     ")"
    ]
   },
@@ -599,7 +599,7 @@
     "try:\n",
     "    solver.solve(domain_factory=lambda: domain)\n",
     "except Exception:\n",
-    "    print(\"the algorithm could not finsh\")\n",
+    "    print(\"the algorithm could not finish\")\n",
     "finally:\n",
     "    signal.alarm(0)"
    ]
@@ -714,7 +714,7 @@
    "outputs": [],
    "source": [
     "print(\n",
-    "    f\"Time of last state: {final_state.t} - Ending time of Task #32: {final_state.tasks_details[32].end}\"\n",
+    "    f\"Time of last state: {final_state.t} - Ending time of Task #32: {final_state.tasks_full_details[32].end}\"\n",
     ")"
    ]
   },

--- a/skdecide/builders/domain/scheduling/scheduling_domains_modelling.py
+++ b/skdecide/builders/domain/scheduling/scheduling_domains_modelling.py
@@ -18,7 +18,11 @@ def rebuild_tasks_complete_details_dict(state: State) -> Dict[int, Task]:
 
 
 def rebuild_all_tasks_dict(state: State) -> Dict[int, Task]:
-    tasks_details = {p.value.id: p.value for p in state.tasks_complete_details}
+    tasks_details = {
+        task_id: Task(id=task_id, start=None, sampled_duration=None)
+        for task_id in state.task_ids
+    }
+    tasks_details.update({p.value.id: p.value for p in state.tasks_complete_details})
     tasks_details.update(state.tasks_details)
     return tasks_details
 
@@ -115,6 +119,7 @@ class State:
         tasks_details: dictionary where the key is the id of a task (int) and the value a Task object. This Task object
             contains information about the task execution and can be used to post-process the run. It is only used
             by the domain to store execution information and not used by scheduling solvers.
+        tasks_full_details: like taks_details but containing all taks, even the ones not completed.
         _current_conditions: set of conditions observed so far, to be used by domains with WithConditionalTask
             properties
 
@@ -190,6 +195,10 @@ class State:
         s.tasks_complete_progress = copy(self.tasks_complete_progress)
         s.tasks_complete_mode = copy(self.tasks_complete_mode)
         return s
+
+    @property
+    def tasks_full_details(self) -> Dict[int, Task]:
+        return rebuild_all_tasks_dict(self)
 
     @property
     def tasks_remaining(self):


### PR DESCRIPTION
After the code optimization made on scheduling algorithms in commit b76e15a86, the attribute `tasks_details` does not keep track of all tasks anymore. Thus:

- we introduce a new attribute `tasks_full_details` which holds also information for non-completed tasks and is actually a property reconstructed on-the-fly via `rebuild_all_tasks_dict`
- we add a dummy task for each task id in `rebuild_all_tasks_dict` output so that we can call a task detail even before starting any task as required in the scheduling notebook