### PR TITLE
Build macos wheel on macos-latest github runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python_version = ["3.7", "3.8", "3.9"]
           build = [ "macos-latest", "ubuntu-latest", "windows-latest" ]
-          test = [ "macos-10.15", "macos-11", "ubuntu-18.04", "ubuntu-20.04", "windows-2019", "windows-2022"]
+          test = [ "macos-10.15", "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "windows-2019", "windows-2022"]
           build_doc = "true"
 
           if "${{ github.event_name }}" != "schedule":
@@ -53,6 +53,7 @@ jobs:
               os_filter = {
                   'macos-10.15'  : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-10.15]') }}"),
                   'macos-11'     : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-11]') }}"),
+                  'macos-12'     : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-12]') }}"),
                   'ubuntu-18.04' : to_bool("${{ contains(github.event.head_commit.message, '[ci: ubuntu-18.04]') }}"),
                   'ubuntu-20.04' : to_bool("${{ contains(github.event.head_commit.message, '[ci: ubuntu-20.04]') }}"),
                   'windows-2019' : to_bool("${{ contains(github.event.head_commit.message, '[ci: windows-2019]') }}"),

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         shell: python3 {0}
         run: |
           python_version = ["3.7", "3.8", "3.9"]
-          build = [ "macos-10.15", "ubuntu-latest", "windows-latest" ]
+          build = [ "macos-latest", "ubuntu-latest", "windows-latest" ]
           test = [ "macos-10.15", "macos-11", "ubuntu-18.04", "ubuntu-20.04", "windows-2019", "windows-2022"]
           build_doc = "true"
 
@@ -252,7 +252,15 @@ jobs:
           export "BOOST_ROOT=$PWD/$BOOST_DIR"
           python -m pip install --upgrade pip
           pip install build poetry-dynamic-versioning
-          python -m build --sdist --wheel
+          # cross-compile for macosx-10.15
+          export MACOSX_DEPLOYMENT_TARGET=10.15
+          python -m build --sdist --wheel "--config-setting=--plat-name=macosx_10_15_x86_64"
+          # hack wheel name to be recognized by macos 10.15
+          wheel_name=$(ls dist/*.whl)
+          new_wheel_name=$(echo $wheel_name | sed -e 's/macosx_.*_x86_64.whl/macosx_10_15_x86_64.whl/')
+          echo "mv $wheel_name $new_wheel_name"
+          mv $wheel_name $new_wheel_name
+
 
       - name: Update build cache from wheels
         if: steps.cache-build-dependencies.outputs.cache-hit != 'true'


### PR DESCRIPTION
Macos-10.15 github runner is deprecated and will be removed starting December (cf https://github.com/actions/runner-images/issues/5583). So we need to move the build on macos-latest (= macos-11 currently) and see if tests still pass on macos-10.15.

The other github runner names are also change for their "$os-latest" aliases when possible to follow more easily the update of github runners.