### PR TITLE
Updating binder for flight planning notebook

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,4 +1,5 @@
 ffmpeg
 freeglut3-dev
+libeccodes-tools
 xvfb
 x11-utils

--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,23 @@ channels:
   - pytorch
   - defaults
 dependencies:
+  - cartopy>=0.21
   - python=3.8
   - pip
   - pytorch::cpuonly
   - pytorch::pytorch
   - pip:
+    - cdsapi
+    - cfgrib
+    - cartopy
     - matplotlib
     - ipywidgets
     - ipympl
     - scikit-decide[all]==0.9.4
     - nbgitpuller
+    - openap
+    - pygeodesy
     - pyvirtualdisplay
     - PyOpenGL-accelerate
     - PyOpenGL
+    - xarray


### PR DESCRIPTION
Adding `libeccodes-tools` as linux package
And the following python packages:
```
- cartopy>=0.21
- cdsapi
- openap
- pygeodesy
- xarray
```