### PR TITLE
Generate doc on a platform for which the wheels have been build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -664,12 +664,7 @@ jobs:
   build-doc:
     needs: [test-ubuntu, setup]
     if: needs.setup.outputs.build_doc == 'true'
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.7"]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ fromJson(needs.setup.outputs.test).ubuntu[0] || fromJson(needs.setup.outputs.test).windows[0] || fromJson(needs.setup.outputs.test).macos[0]}}
 
     steps:
       - name: Set env variables for github+binder links in doc


### PR DESCRIPTION
Make sure the documentation is always generated on a platform for which the wheel have been built and tested. Fix for #220 