### PR TITLE
Install minizinc binary in binder env

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,17 @@
+ #!/bin/bash
+
+set -ex
+
+pwd
+ls
+
+# install minizinc
+mkdir minizinc_install
+cd minizinc_install
+curl -o minizinc.AppImage -L https://github.com/MiniZinc/MiniZincIDE/releases/download/2.6.3/MiniZincIDE-2.6.3-x86_64.AppImage
+chmod +x minizinc.AppImage
+./minizinc.AppImage --appimage-extract
+cd ..
+export PATH="$(pwd)/minizinc_install/squashfs-root/usr/bin/":$PATH
+export LD_LIBRARY_PATH="$(pwd)/minizinc_install/squashfs-root/usr/lib":$LD_LIBRARY_PATH
+minizinc --version

--- a/start
+++ b/start
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PATH="$(pwd)/minizinc_install/squashfs-root/usr/bin/":$PATH
+export LD_LIBRARY_PATH="$(pwd)/minizinc_install/squashfs-root/usr/lib":$LD_LIBRARY_PATH
+exec "$@"


### PR DESCRIPTION
Minizinc binary will not anymore be part of scikit-decide distribution. 
We install it in "postBuild" (done once when building the env image) 
We set the paths properly in "start" (read at each notebook launch)