### PR TITLE
Install last nightly build in binder env for master version

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -15,3 +15,17 @@ cd ..
 export PATH="$(pwd)/minizinc_install/squashfs-root/usr/bin/":$PATH
 export LD_LIBRARY_PATH="$(pwd)/minizinc_install/squashfs-root/usr/lib":$LD_LIBRARY_PATH
 minizinc --version
+
+# install nightly build (only for master version binder environment)
+nightly_build_url="https://github.com/airbus/scikit-decide/releases/download/nightly/nightly_57_46902c1e.zip"  # to be updated by nightly releases
+# skip if no nightly build set
+if [ ! -z ${nightly_build_url} ]; then
+    # download and unzip
+    wget --output-document=nightly.zip ${nightly_build_url}
+    unzip nightly.zip
+    # get the appropriate wheel from python version
+    wheel_pythonversion_tag=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
+    wheel_path=$(ls dist/scikit_decide*${wheel_pythonversion_tag}*manylinux*.whl)
+    # install scikit-decide with all extras
+    pip install ${wheel_path}[all]
+fi


### PR DESCRIPTION
Here we set manually the url of the nightly build. The github action will be modified so that
- a new nightly build will update this url
- the environment for a release will empty this url

Note that we do not touch the environemnt.yml so that previous release of scikit-decide should already been installed with all its dependencies in docker cache.
It should speed-up the new image build as only updated dependencies should be downloaded.
