### PR TITLE
Update isort version to make it work with newer version of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         files: ^cpp/src/.*\.[ch]{2}$
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
The last version of pre-commit is failing to install the isort hook for the older version. It is now working properly.

You may actually not have noticed this issue due to pre-commit cache. It appears after a  ̀pre-commit clean` or in the actions if the cache for the hooks is not hit.