### PR TITLE
Fix library build with last version of poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 
 [tool.poetry.build]
 script = "builder.py"
+generate-setup-file = true
 
 [tool.poetry-dynamic-versioning]
 enable = true
@@ -123,5 +124,5 @@ profile = "black"
 all = true
 
 [build-system]
-requires = ["poetry-core>=1.0.0,<1.5", "setuptools>=49.2.1", "poetry-dynamic-versioning>=0.13.0"]
+requires = ["poetry-core>=1.0.0", "setuptools>=49.2.1", "poetry-dynamic-versioning>=0.13.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
By adding an argument to "tool.poetry.build" section, we go back to previous behaviour and make the build process work with poetry-core 1.15