### PR TITLE
Fix issue when building doc on node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -707,8 +707,11 @@ jobs:
 
       - name: generate documentation
         run: |
+          yarn global add vuepress && yarn install
+          export NODE_OPTIONS=--openssl-legacy-provider  # avoid issue with node 18 and current dependencies (ok because no interaction with external network during the build)
           export DO_SKIP_MZN_CHECK=1  # avoid having to install minizinc for discrete-optimization
-          yarn global add vuepress && yarn install && yarn docs:build && touch docs/.vuepress/dist/.nojekyll
+          yarn docs:build
+          touch docs/.vuepress/dist/.nojekyll
 
       - name: upload as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -687,8 +687,11 @@ jobs:
 
       - name: generate documentation
         run: |
+          yarn global add vuepress && yarn install
+          export NODE_OPTIONS=--openssl-legacy-provider  # avoid issue with node 18 and current dependencies (ok because no interaction with external network during the build)
           export DO_SKIP_MZN_CHECK=1  # avoid having to install minizinc for discrete-optimization
-          yarn global add vuepress && yarn install && yarn docs:build && touch docs/.vuepress/dist/.nojekyll
+          yarn docs:build
+          touch docs/.vuepress/dist/.nojekyll
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
The ssl behaviour change in last node version. This breaks the doc build with the current dependencies. We can force to use legacy openssl provider. It could be a security issue but not here as there is no interaction with external network during the build process.

See
https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported 

Another solution would be to find the modification in the dependencies that removes this error.
As done [here](https://github.com/nrwl/nx/issues/14331).