### PR TITLE
Robust check state equality in get_next_state

### DIFF
--- a/skdecide/hub/domain/gym/gym.py
+++ b/skdecide/hub/domain/gym/gym.py
@@ -819,6 +819,12 @@ class D(
     pass
 
 
+def check_equality_state(st1, st2):
+    return (isinstance(st1, np.ndarray) and np.array_equal(st1, st2)) or (
+        not isinstance(st1, np.ndarray) and st1 == st2
+    )
+
+
 class DeterministicGymDomain(D):
     """This class wraps a deterministic OpenAI Gym environment (gym.env) as a scikit-decide domain.
 
@@ -869,7 +875,7 @@ class DeterministicGymDomain(D):
         env = memory._context[0]
         if self._set_state is None or self._get_state is None:
             env = deepcopy(env)
-        elif memory._context[4] != self._get_state(env):
+        elif not check_equality_state(memory._context[4], self._get_state(env)):
             self._set_state(env, memory._context[4])
         self._gym_env = env  # Just in case the simulation environment would be different from the planner's environment...
         obs, reward, done, info = env.step(action)


### PR DESCRIPTION
in DeterministicGymDomain.get_next_state(), we check the state equality before calling set_state function. 
The equality check was failing in the case where the state is a numpy array. (classic error ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all())

New equality check is now robust to this possible case.

