### PR TITLE
Preinstall gym==0.21.0 with option `--no-use-pep517`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
           # cross-compile for macosx-10.15
           export MACOSX_DEPLOYMENT_TARGET=10.15
           python -m build --sdist --wheel "--config-setting=--plat-name=macosx_10_15_x86_64"
-          # hack wheel name to be recognized by macos 10.15
+          # hack wheel name to be recognized by macos 10.15
           wheel_name=$(ls dist/*.whl)
           new_wheel_name=$(echo $wheel_name | sed -e 's/macosx_.*_x86_64.whl/macosx_10_15_x86_64.whl/')
           echo "mv $wheel_name $new_wheel_name"
@@ -424,6 +424,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # install remaining dependencies
           python -m pip install --upgrade pip
           python -m pip install pytest
 
@@ -506,6 +511,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # install remaining dependencies
           python -m pip install --upgrade pip
           python -m pip install pytest
 
@@ -588,6 +598,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # install remaining dependencies          
           python -m pip install --upgrade pip
           python -m pip install pytest docopt commonmark
 
@@ -681,7 +696,7 @@ jobs:
           echo "AUTODOC_BINDER_ENV_GH_BRANCH=${AUTODOC_BINDER_ENV_GH_BRANCH}" >> $GITHUB_ENV
           echo "AUTODOC_NOTEBOOKS_REPO_URL=${AUTODOC_NOTEBOOKS_REPO_URL}" >> $GITHUB_ENV
           echo "AUTODOC_NOTEBOOKS_BRANCH=${AUTODOC_NOTEBOOKS_BRANCH}" >> $GITHUB_ENV
-          # check computed variables
+          # check computed variables
           echo "Binder env: ${AUTODOC_BINDER_ENV_GH_REPO_NAME}/${AUTODOC_BINDER_ENV_GH_BRANCH}"
           echo "Notebooks source: ${AUTODOC_NOTEBOOKS_REPO_URL}/tree/${AUTODOC_NOTEBOOKS_BRANCH}"
 
@@ -702,6 +717,13 @@ jobs:
 
       - name: Install scikit-decide
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # upgrade pip
+          python -m pip install --upgrade pip
+          # find proper wheel and install it
           python_version=${{ matrix.python-version }}
           wheelfile=$(ls ./wheels/scikit_decide*-cp${python_version/\./}-*manylinux*.whl)
           pip install ${wheelfile}[all]
@@ -903,7 +925,7 @@ jobs:
       # only if a nightly release occured
       if: ${{ steps.asset.outputs.result != '' }}
       run: |
-        # update nightly_build_url to install last nightly build over last release
+        # update nightly_build_url to install last nightly build over last release
         sed -i -e 's|nightly_build_url="[^"]*"|nightly_build_url="${{ steps.asset.outputs.result }}"|' postBuild
         git config user.name "Actions"
         git config user.email "actions@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # install remaining dependencies
           python -m pip install --upgrade pip
           python -m pip install pytest
 
@@ -422,6 +427,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # install remaining dependencies
           python -m pip install --upgrade pip
           python -m pip install pytest
 
@@ -503,6 +513,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # install remaining dependencies
           python -m pip install --upgrade pip
           python -m pip install pytest
 
@@ -681,6 +696,13 @@ jobs:
 
       - name: Install scikit-decide
         run: |
+          # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+          python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          python -m pip install gym==0.21.0 --no-use-pep517
+          # upgrade pip
+          python -m pip install --upgrade pip
+          # find proper wheel and install it
           python_version=${{ env.python_version }}
           wheelfile=$(ls ./wheels/scikit_decide*-cp${python_version/\./}-*manylinux*.whl)
           pip install ${wheelfile}[all]

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -67,29 +67,38 @@ Here are the steps to follow:
     pip install -U pip
     ```
 
-- Use poetry to install the project:
+  - Use poetry to install the project:
 
-    - Install [poetry](https://python-poetry.org/docs/master/#installation).
-        ```shell
-        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
-        export PATH="$HOME/.local/bin:$PATH"  # add path to poetry
-        ```
+      - Install [poetry](https://python-poetry.org/docs/master/#installation).
+          ```shell
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+          export PATH="$HOME/.local/bin:$PATH"  # add path to poetry
+          ```
 
-    - Install poetry-dynamic-versioning in poetry root env
-        ```shell
-        poetry self add poetry-dynamic-versioning
-        ```
+      - Install poetry-dynamic-versioning in poetry root env
+          ```shell
+          poetry self add poetry-dynamic-versioning
+          ```
 
-    - Specify to poetry the python version to use so that it creates the appropriate virtual environment.
-        ```shell
-        poetry env use 3.8.11
-        ```
+      - Specify to poetry the python version to use so that it creates the appropriate virtual environment.
+          ```shell
+          poetry env use 3.8.11
+          ```
+      
+      - Preinstall gym 0.21.0 with appropriate option to avoid an error during installation 
+        (see this [issue](https://github.com/openai/gym/issues/3176) 
+        and this [solution](https://github.com/python-poetry/poetry/issues/3433#issuecomment-840509576)):
+          ```shell
+          poetry run python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          poetry run python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+          poetry run python -m pip install gym==0.21.0 --no-use-pep517
+          ```
 
-    - Install all dependencies as defined in `poetry.lock`, build and install the c++ library.
-        ```shell
-        rm -rf build  # removing previous build
-        poetry install --extras all
-        ```
+      - Install all dependencies as defined in `poetry.lock`, build and install the c++ library.
+          ```shell
+          rm -rf build  # removing previous build
+          poetry install --extras all
+          ```
 
 #### Alternate installation with conda + poetry
 
@@ -120,6 +129,15 @@ as it can also be installed by conda via the conda-forge channel.
 - Install poetry-dynamic-versioning in poetry root env
     ```shell
     poetry self add poetry-dynamic-versioning
+    ```
+
+- Preinstall gym 0.21.0 with appropriate option to avoid an error during installation 
+  (see this [issue](https://github.com/openai/gym/issues/3176) 
+  and this [solution](https://github.com/python-poetry/poetry/issues/3433#issuecomment-840509576)):
+    ```shell
+    poetry run python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+    poetry run python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+    poetry run python -m pip install gym==0.21.0 --no-use-pep517
     ```
 
 - Install all dependencies as defined in `poetry.lock`, build and install the c++ library.

--- a/docs/install.md
+++ b/docs/install.md
@@ -122,3 +122,25 @@ Alternatively you can choose to only install the core library, which is enough i
 pip install -U pip
 pip install -U scikit-decide
 ```
+
+## Troubleshooting
+
+You may encounter an [error when installing `gym==0.21.0`](https://github.com/openai/gym/issues/3176) which happens to be a dependency of `scikit-decide[all]`. 
+This is because its installation does not respect PEP 517 which is enforced by default by last versions of pip and setuptools. 
+The solution is to install it beforehand:
+```shell
+# preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
+python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
+python -m pip install gym==0.21.0 --no-use-pep517
+# upgrade pip
+python -m pip install --upgrade pip
+# install scikit-decide and remaining dependencies
+pip install -U scikit-decide[all]
+```
+
+::: tip Note
+Newer versions of gym or [gymnasium](https://gymnasium.farama.org/), typically greater than 0.26 are not yet possible 
+because of a conflict between [`ray[rllib]`](https://github.com/ray-project/ray/issues/34396) 
+and [`stable-baselines3`](https://github.com/DLR-RM/stable-baselines3/issues/1452).
+:::


### PR DESCRIPTION
New versions of pip/setuptools enforce pep 517 by default, which is not respected by gym 0.21.0 install. 
So we preinstall with option `--no-use-pep517` so that the installation of `scikit-decide[all]` works.

Note that it could be also nice to upgrade to gymnasium 0.26 and later but this is not yet possible because of a conflict between recent versions of [`ray[rllib]`](https://github.com/ray-project/ray/issues/34396) and [`stable-baselines3`](https://github.com/DLR-RM/stable-baselines3/issues/1452) which are each fixing a different version of gymnasium.

We also add this tip in the documentation to install scikit-decide (normal process and developper mode).