### PR TITLE
Test now on ubuntu-22.04 instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
           python_version = ["3.7", "3.8", "3.9", "3.10"]
           build = [ "macos-latest", "ubuntu-latest", "windows-latest" ]
-          test = [ "macos-10.15", "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "windows-2019", "windows-2022"]
+          test = [ "macos-10.15", "macos-11", "macos-12", "ubuntu-22.04", "ubuntu-20.04", "windows-2019", "windows-2022"]
           build_doc = "true"
 
           if "${{ github.event_name }}" != "schedule":
@@ -59,7 +59,7 @@ jobs:
                   'macos-10.15'  : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-10.15]') }}"),
                   'macos-11'     : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-11]') }}"),
                   'macos-12'     : to_bool("${{ contains(github.event.head_commit.message, '[ci: macos-12]') }}"),
-                  'ubuntu-18.04' : to_bool("${{ contains(github.event.head_commit.message, '[ci: ubuntu-18.04]') }}"),
+                  'ubuntu-22.04' : to_bool("${{ contains(github.event.head_commit.message, '[ci: ubuntu-22.04]') }}"),
                   'ubuntu-20.04' : to_bool("${{ contains(github.event.head_commit.message, '[ci: ubuntu-20.04]') }}"),
                   'windows-2019' : to_bool("${{ contains(github.event.head_commit.message, '[ci: windows-2019]') }}"),
                   'windows-2022' : to_bool("${{ contains(github.event.head_commit.message, '[ci: windows-2022]') }}"),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
           python_version = ["3.7", "3.8", "3.9", "3.10"]
           build_dict = { "macos":["macos-10.15"], "ubuntu":["ubuntu-latest"], "windows":["windows-latest"] }
-          test_dict = { "macos":["macos-10.15", "macos-11"], "ubuntu":["ubuntu-18.04", "ubuntu-20.04"], "windows":["windows-2019", "windows-2022" ]}
+          test_dict = { "macos":["macos-10.15", "macos-11"], "ubuntu":["ubuntu-22.04", "ubuntu-20.04"], "windows":["windows-2019", "windows-2022" ]}
           deploy_test_pypi = "true"
 
           if "${{ contains(github.event.head_commit.message, '[ci: skip-deploy-test-pypi]') }}" == "true":


### PR DESCRIPTION
The github runners for ubuntu-18.04 are not maintained anymore: https://github.com/actions/runner-images/issues/6002

So instead of testing on 18.04 and 20.04, we test on 20.04 and 22.04.