### PR TITLE
Update gym 0.21.0 install by bounding setuptools version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,6 +425,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # install remaining dependencies
@@ -512,6 +513,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # install remaining dependencies
@@ -599,6 +601,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # install remaining dependencies          
@@ -718,6 +721,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,6 +342,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # install remaining dependencies
@@ -429,6 +430,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # install remaining dependencies
@@ -515,6 +517,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # install remaining dependencies
@@ -698,6 +701,7 @@ jobs:
         run: |
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # upgrade pip

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -90,6 +90,7 @@ Here are the steps to follow:
         and this [solution](https://github.com/python-poetry/poetry/issues/3433#issuecomment-840509576)):
           ```shell
           poetry run python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+          poetry run python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
           poetry run python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           poetry run python -m pip install gym==0.21.0 --no-use-pep517
           ```
@@ -136,6 +137,7 @@ as it can also be installed by conda via the conda-forge channel.
   and this [solution](https://github.com/python-poetry/poetry/issues/3433#issuecomment-840509576)):
     ```shell
     poetry run python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+    poetry run python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
     poetry run python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
     poetry run python -m pip install gym==0.21.0 --no-use-pep517
     ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -131,6 +131,7 @@ The solution is to install it beforehand:
 ```shell
 # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
 python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
+python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
 python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
 python -m pip install gym==0.21.0 --no-use-pep517
 # upgrade pip


### PR DESCRIPTION
Gym 0.21.0 requirement list is broken and the install process cannot work anymore with latest version of setuptools.

We update tips in documentation and install process in github actions.