### PR TITLE
Change dependencies between github actions jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,7 +393,7 @@ jobs:
           path: dist/*.whl
 
   test-windows:
-    needs: [build-windows, setup]
+    needs: [build-macos, build-ubuntu, build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).windows }}
@@ -483,7 +483,7 @@ jobs:
           pytest -v -s tests/scheduling
 
   test-macos:
-    needs: [build-macos, setup]
+    needs: [build-macos, build-ubuntu, build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).macos }}
@@ -572,7 +572,7 @@ jobs:
           pytest -v -s tests/scheduling
 
   test-ubuntu:
-    needs: [build-ubuntu, setup]
+    needs: [build-macos, build-ubuntu, build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).ubuntu }}
@@ -665,7 +665,7 @@ jobs:
           python tests/test_guide.py
 
   build-doc:
-    needs: [test-ubuntu, setup]
+    needs: [build-macos, build-ubuntu, build-windows, test-ubuntu, setup]
     if: needs.setup.outputs.build_doc == 'true'
     strategy:
       matrix:
@@ -742,7 +742,7 @@ jobs:
           path: docs/.vuepress/dist
 
   upload-doc:
-    needs: [build-doc, test-windows, test-macos]
+    needs: [build-doc, test-windows, test-macos, test-ubuntu]
     if: github.ref == 'refs/heads/master'
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,7 +310,7 @@ jobs:
           path: dist/*.whl
 
   test-windows:
-    needs: [build-windows, setup]
+    needs: [build-macos, build-ubuntu, build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).windows }}
@@ -400,7 +400,7 @@ jobs:
           pytest -v -s tests/scheduling
 
   test-macos:
-    needs: [build-macos, setup]
+    needs: [build-macos, build-ubuntu, build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).macos }}
@@ -489,7 +489,7 @@ jobs:
           pytest -v -s tests/scheduling
 
   test-ubuntu:
-    needs: [build-ubuntu, setup]
+    needs: [build-macos, build-ubuntu, build-windows, setup]
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).ubuntu }}


### PR DESCRIPTION
Sometimes, if not waiting for all builds to finish, the artifact download in test steps may fail if it happens approximately at the same time another build finishes. (The artifact is then supposed to contain wheels not yet fully uploaded)