### PR TITLE
Synchronize package dependencies between build.yml and release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,12 +343,15 @@ jobs:
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
           python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
+          python -m pip install "importlib-metadata<5" "virtualenv==20.16.6"  # cannot import gym with importlib-metadata >= 5 and python<3.8
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # preinstall ray[rllib]<2.3.0 because starting from 2.3.0, ray also install gym > 0.21
           python -m pip install --upgrade pip
           python -m pip install "ray[rllib]<2.3.0"
-          # install remaining dependencies
+          # preinstall stable-baselines3<2.0.0 because starting from 2.0.0, stable-baselines3 requires gym > 0.26
+          python -m pip install "stable-baselines3<2.0.0"
+          # install remaining dependencies
           python -m pip install pytest
 
       - name: Download artifacts
@@ -433,12 +436,15 @@ jobs:
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
           python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
+          python -m pip install "importlib-metadata<5" "virtualenv==20.16.6"  # cannot import gym with importlib-metadata >= 5 and python<3.8
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # preinstall ray[rllib]<2.3.0 because starting from 2.3.0, ray also install gym > 0.21
           python -m pip install --upgrade pip
           python -m pip install "ray[rllib]<2.3.0"
-          # install remaining dependencies
+          # preinstall stable-baselines3<2.0.0 because starting from 2.0.0, stable-baselines3 requires gym > 0.26
+          python -m pip install "stable-baselines3<2.0.0"
+          # install remaining dependencies
           python -m pip install pytest
 
       - name: Download artifacts
@@ -522,12 +528,15 @@ jobs:
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
           python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
+          python -m pip install "importlib-metadata<5" "virtualenv==20.16.6"  # cannot import gym with importlib-metadata >= 5 and python<3.8
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # preinstall ray[rllib]<2.3.0 because starting from 2.3.0, ray also install gym > 0.21
           python -m pip install --upgrade pip
           python -m pip install "ray[rllib]<2.3.0"
-          # install remaining dependencies
+          # preinstall stable-baselines3<2.0.0 because starting from 2.0.0, stable-baselines3 requires gym > 0.26
+          python -m pip install "stable-baselines3<2.0.0"
+          # install remaining dependencies
           python -m pip install pytest
 
       - name: Download artifacts
@@ -708,12 +717,15 @@ jobs:
           # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
           python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
           python -m pip install "setuptools<67"  # starting with setuptools 67, gym 0.21.0 is not intallable anymore
+          python -m pip install "importlib-metadata<5" "virtualenv==20.16.6"  # cannot import gym with importlib-metadata >= 5 and python<3.8
           python -m pip uninstall -y wheel  # wheel must not be here to fall back directly to python setup.py
           python -m pip install gym==0.21.0 --no-use-pep517
           # preinstall ray[rllib]<2.3.0 because starting from 2.3.0, ray also install gym > 0.21
           python -m pip install --upgrade pip
           python -m pip install "ray[rllib]<2.3.0"
-          # find proper wheel and install it
+          # preinstall stable-baselines3<2.0.0 because starting from 2.0.0, stable-baselines3 requires gym > 0.26
+          python -m pip install "stable-baselines3<2.0.0"
+          # find proper wheel and install it
           python_version=${{ env.python_version }}
           wheelfile=$(ls ./wheels/scikit_decide*-cp${python_version/\./}-*manylinux*.whl)
           pip install ${wheelfile}[all]


### PR DESCRIPTION
Package dependencies were recently changed in build.yml but not in release.yml, which makes the release process fail.