### PR TITLE
Remove deprecated mybinder federations and  update the gesis one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -673,17 +673,15 @@ jobs:
           # get sha1 to be used by binder for the environment
           BINDER_RELEASE_ENV_SHA1=$(git rev-parse --verify HEAD)
           echo "BINDER_RELEASE_ENV_SHA1=${BINDER_RELEASE_ENV_SHA1}" >> $GITHUB_ENV
-          # push binder branch so that reference to release binder env exists on remote
+          # push binder branch so that reference to release binder env exists on remote
           git push origin binder
           # switch back to original branch
           git checkout $TAG_NAME
 
       - name: Trigger a build on each BinderHub deployments in the mybinder.org federation
         run: |
-          bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
           bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
-          bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
-          bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://notebooks.gesis.org/binder/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
 
       - name: Set env variables for github+binder links in doc
         run: |


### PR DESCRIPTION
Release deployment fails because mybinder federations changed and some of the federations used in `release.yml` are not reachable anymore.