### PR TITLE
Add --all-files option to pre-commit command to avoid skipping the test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: pre-commit checks
-        run: pre-commit run --show-diff-on-failure --color=always
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   build-windows:
     needs: [setup]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: pre-commit checks
-        run: pre-commit run --show-diff-on-failure --color=always
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   build-windows:
     needs: [setup]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
-    -   id: pretty-format-json
-        args: ["--autofix", "--no-sort-keys", "--indent", "4"]
 
   - repo: https://github.com/psf/black
     rev: 22.3.0 # Replace by any tag/version: https://github.com/psf/black/tags

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -84,9 +84,9 @@ Here are the steps to follow:
           ```shell
           poetry env use 3.8.11
           ```
-      
-      - Preinstall gym 0.21.0 with appropriate option to avoid an error during installation 
-        (see this [issue](https://github.com/openai/gym/issues/3176) 
+
+      - Preinstall gym 0.21.0 with appropriate option to avoid an error during installation
+        (see this [issue](https://github.com/openai/gym/issues/3176)
         and this [solution](https://github.com/python-poetry/poetry/issues/3433#issuecomment-840509576)):
           ```shell
           poetry run python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore
@@ -132,8 +132,8 @@ as it can also be installed by conda via the conda-forge channel.
     poetry self add poetry-dynamic-versioning
     ```
 
-- Preinstall gym 0.21.0 with appropriate option to avoid an error during installation 
-  (see this [issue](https://github.com/openai/gym/issues/3176) 
+- Preinstall gym 0.21.0 with appropriate option to avoid an error during installation
+  (see this [issue](https://github.com/openai/gym/issues/3176)
   and this [solution](https://github.com/python-poetry/poetry/issues/3433#issuecomment-840509576)):
     ```shell
     poetry run python -m pip install "pip==22"  # starting with pip 23.1, gym 0.21.0 is not intallable anymore

--- a/docs/install.md
+++ b/docs/install.md
@@ -125,8 +125,8 @@ pip install -U scikit-decide
 
 ## Troubleshooting
 
-You may encounter an [error when installing `gym==0.21.0`](https://github.com/openai/gym/issues/3176) which happens to be a dependency of `scikit-decide[all]`. 
-This is because its installation does not respect PEP 517 which is enforced by default by last versions of pip and setuptools. 
+You may encounter an [error when installing `gym==0.21.0`](https://github.com/openai/gym/issues/3176) which happens to be a dependency of `scikit-decide[all]`.
+This is because its installation does not respect PEP 517 which is enforced by default by last versions of pip and setuptools.
 The solution is to install it beforehand:
 ```shell
 # preinstall gym==0.21.0 with legacy method (python setup.py) because its requirements list is broken
@@ -145,7 +145,7 @@ pip install -U scikit-decide[all]
 ```
 
 ::: tip Note
-Newer versions of gym or [gymnasium](https://gymnasium.farama.org/), typically greater than 0.26 are not yet possible 
-because of a conflict between [`ray[rllib]`](https://github.com/ray-project/ray/issues/34396) 
+Newer versions of gym or [gymnasium](https://gymnasium.farama.org/), typically greater than 0.26 are not yet possible
+because of a conflict between [`ray[rllib]`](https://github.com/ray-project/ray/issues/34396)
 and [`stable-baselines3`](https://github.com/DLR-RM/stable-baselines3/issues/1452).
 :::

--- a/examples/up_bridge.py
+++ b/examples/up_bridge.py
@@ -3,20 +3,20 @@
 # LICENSE file in the root directory of this source tree.
 
 import sys
-from skdecide.hub.domain.up import UPDomain
-from skdecide.hub.solver.up import UPSolver
-from skdecide.hub.solver.lazy_astar import LazyAstar
 
 import unified_planning
 from unified_planning.shortcuts import (
-    UserType,
     BoolType,
-    OneshotPlanner,
     Fluent,
     InstantaneousAction,
     Not,
+    OneshotPlanner,
+    UserType,
 )
 
+from skdecide.hub.domain.up import UPDomain
+from skdecide.hub.solver.lazy_astar import LazyAstar
+from skdecide.hub.solver.up import UPSolver
 from skdecide.utils import rollout
 
 # Example 1: Solving a basic example, the same as

--- a/skdecide/hub/domain/flight_planning/__init__.py
+++ b/skdecide/hub/domain/flight_planning/__init__.py
@@ -1,4 +1,3 @@
 # Copyright (c) AIRBUS and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-

--- a/skdecide/hub/domain/up/__init__.py
+++ b/skdecide/hub/domain/up/__init__.py
@@ -2,4 +2,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .up import UPDomain, SkUPState, SkUPAction
+from .up import SkUPAction, SkUPState, UPDomain

--- a/skdecide/hub/domain/up/up.py
+++ b/skdecide/hub/domain/up/up.py
@@ -3,30 +3,29 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Dict, List, Optional, Tuple, Union
+
 import gym
-
 import unified_planning as up
-from unified_planning.model.state import UPState
-
-from skdecide.core import ImplicitSpace, Space, Value
-from skdecide.domains import DeterministicPlanningDomain
-from skdecide.hub.space.gym import ListSpace, DictSpace
-from skdecide.utils import logger
-
-from unified_planning.model import Problem, UPState, InstantaneousAction, FNode
-from unified_planning.plans import ActionInstance
+from unified_planning.engines.compilers.grounder import GrounderHelper
+from unified_planning.engines.sequential_simulator import (
+    UPSequentialSimulator,
+    evaluate_quality_metric,
+)
+from unified_planning.exceptions import UPValueError
+from unified_planning.model import FNode, InstantaneousAction, Problem, UPState
 from unified_planning.model.metrics import (
     MaximizeExpressionOnFinalState,
     Oversubscription,
     TemporalOversubscription,
 )
+from unified_planning.model.state import UPState
+from unified_planning.plans import ActionInstance
 from unified_planning.shortcuts import FluentExp
-from unified_planning.engines.sequential_simulator import (
-    UPSequentialSimulator,
-    evaluate_quality_metric,
-)
-from unified_planning.engines.compilers.grounder import GrounderHelper
-from unified_planning.exceptions import UPValueError
+
+from skdecide.core import ImplicitSpace, Space, Value
+from skdecide.domains import DeterministicPlanningDomain
+from skdecide.hub.space.gym import DictSpace, ListSpace
+from skdecide.utils import logger
 
 
 class SkUPState:

--- a/skdecide/hub/solver/up/up.py
+++ b/skdecide/hub/solver/up/up.py
@@ -4,15 +4,15 @@
 
 from __future__ import annotations
 
+from typing import Any, Callable, Dict, List
+
 from unified_planning.engines import Engine
 from unified_planning.exceptions import UPValueError
 from unified_planning.shortcuts import FluentExp, SequentialSimulator
 
-from skdecide.hub.domain.up import UPDomain, SkUPState, SkUPAction
-from typing import Any, Callable, Dict, List
-
 from skdecide import Solver, Value
 from skdecide.builders.solver import DeterministicPolicies, Utilities
+from skdecide.hub.domain.up import SkUPAction, SkUPState, UPDomain
 
 
 # TODO: remove Markovian req?

--- a/tests/domains/python/test_up_bridge_domain.py
+++ b/tests/domains/python/test_up_bridge_domain.py
@@ -2,10 +2,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pytest
 import sys
 
 import gym
+import pytest
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
@@ -13,11 +13,11 @@ def test_up_bridge_domain():
     noexcept = True
 
     try:
-        from skdecide.hub.domain.up import UPDomain
-        from skdecide.hub.solver.lazy_astar import LazyAstar
-
         import unified_planning
         from unified_planning.shortcuts import Fluent, InstantaneousAction, Not
+
+        from skdecide.hub.domain.up import UPDomain
+        from skdecide.hub.solver.lazy_astar import LazyAstar
 
         x = Fluent("x")
         y = Fluent("y")

--- a/tests/solvers/python/test_up_bridge_solver.py
+++ b/tests/solvers/python/test_up_bridge_solver.py
@@ -3,8 +3,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import platform
-import pytest
 import sys
+
+import pytest
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
@@ -12,12 +13,12 @@ def test_up_bridge_solver_classic():
     noexcept = True
 
     try:
-        from skdecide.hub.domain.up import UPDomain, SkUPAction
-        from skdecide.hub.solver.up import UPSolver
-
         import unified_planning
-        from unified_planning.shortcuts import UserType, BoolType, OneshotPlanner
         from unified_planning.plans import ActionInstance
+        from unified_planning.shortcuts import BoolType, OneshotPlanner, UserType
+
+        from skdecide.hub.domain.up import SkUPAction, UPDomain
+        from skdecide.hub.solver.up import UPSolver
 
         Location = UserType("Location")
         robot_at = unified_planning.model.Fluent("robot_at", BoolType(), l=Location)
@@ -86,16 +87,16 @@ def test_up_bridge_solver_numeric():
     noexcept = True
 
     try:
-        from skdecide.hub.domain.up import UPDomain
-        from skdecide.hub.solver.up import UPSolver
-
         import unified_planning
         from unified_planning.shortcuts import (
-            OneshotPlanner,
             Fluent,
             InstantaneousAction,
             Not,
+            OneshotPlanner,
         )
+
+        from skdecide.hub.domain.up import UPDomain
+        from skdecide.hub.solver.up import UPSolver
 
         x = Fluent("x")
         y = Fluent("y")


### PR DESCRIPTION
No tests were actually done by the linter action because `pre-commit run` look only files in the index by default.
When checkouting a whole PR, no files are in the index so no files are checked.

Previously, the job returned something like

    Trim Trailing Whitespace.............................(no files to check)Skipped
    Fix End of Files.....................................(no files to check)Skipped
    Check Yaml...........................................(no files to check)Skipped
    Check for added large files..........................(no files to check)Skipped
    Pretty format JSON...................................(no files to check)Skipped
    isort (python).......................................(no files to check)Skipped
    black................................................(no files to check)Skipped
    nbqa-isort...........................................(no files to check)Skipped
    nbqa-black...........................................(no files to check)Skipped
    nbqa-pycln...........................................(no files to check)Skipped
    nbstripout...........................................(no files to check)Skipped

Now the checks are done (and should read as "Passed") 
We make a `pre-commit run --all-files` in this commit to have the job pass.

We also remove the pretty-format-json hook which was tampering with the notebooks (oddly only remotely on the github runner, not locally on my laptop), and was not very useful for the repository anyway.