### PR TITLE
Correct CGP behaviour regarding verbosity and Restorable API

### DIFF
--- a/skdecide/hub/solver/cgp/cgp.py
+++ b/skdecide/hub/solver/cgp/cgp.py
@@ -303,6 +303,7 @@ class CGPWrapper(Solver, DeterministicPolicies, Restorable):
             evaluator,
             self._folder_name,
             self._n_cpus,
+            verbose=self._verbose
         )
         es.run(self._n_it)
 

--- a/skdecide/hub/solver/cgp/cgp.py
+++ b/skdecide/hub/solver/cgp/cgp.py
@@ -201,7 +201,7 @@ def denorm(vals, types):
         return out
 
 
-class CGPWrapper(Solver, DeterministicPolicies, Restorable):
+class CGPWrapper(Solver, DeterministicPolicies):
     T_domain = D
 
     def __init__(
@@ -326,12 +326,6 @@ class CGPWrapper(Solver, DeterministicPolicies, Restorable):
 
     def _is_policy_defined_for(self, observation: D.T_agent[D.T_observation]) -> bool:
         return True
-
-    def _save(self, path: str) -> None:
-        pass  # TODO
-
-    def _load(self, path: str) -> None:
-        pass  # TODO
 
     def _get_default_function_lib(self):
         return [

--- a/skdecide/hub/solver/cgp/pycgp/cgpes.py
+++ b/skdecide/hub/solver/cgp/pycgp/cgpes.py
@@ -21,6 +21,7 @@ class CGPES:
         evaluator,
         folder="genomes",
         num_cpus=1,
+        verbose=True,
     ):
         self.num_offsprings = num_offsprings
         self.mutation_rate_nodes = mutation_rate_nodes
@@ -30,6 +31,7 @@ class CGPES:
         self.evaluator = evaluator
         self.num_cpus = num_cpus
         self.folder = folder
+        self.verbose = verbose
         if self.num_cpus > 1:
             self.evaluator_pool = []
             for i in range(self.num_offsprings):
@@ -82,15 +84,17 @@ class CGPES:
                 self.father = self.offsprings[best_offspring]
                 self.father_was_updated = True
             # display stats
-            print(
-                self.it,
-                "\t",
-                self.current_fitness,
-                "\t",
-                self.father_was_updated,
-                "\t",
-                self.offspring_fitnesses,
-            )
+            if self.verbose:
+                print(
+                    self.it,
+                    "\t",
+                    self.current_fitness,
+                    "\t",
+                    self.father_was_updated,
+                    "\t",
+                    self.offspring_fitnesses,
+                )
+                print("====================================================")
             self.logfile.write(
                 str(self.it)
                 + "\t"
@@ -102,7 +106,6 @@ class CGPES:
                 + "\n"
             )
             self.logfile.flush()
-            print("====================================================")
             if self.father_was_updated:
                 # print(self.father.genome)
                 self.father.save(


### PR DESCRIPTION
This PR fixes #177.

- We remove all prints when verbose=False
- We remove inheritance from Restorable since CGPWrapper did not implement `_save()` nor `_load()`.

To see how verbosity is fixed you can compare how the following snippets behave before and after the PR:

```python
import gym
from skdecide.hub.domain.gym import (
    GymDomain,

)
from skdecide.hub.solver.cgp import CGP


ENV_NAME = "MountainCarContinuous-v0"
domain_factory = lambda: GymDomain(gym.make(ENV_NAME))

print("*** With verbosity")
solver = CGP("TEMP_CGP", n_it=2, verbose=True)
GymDomain.solve_with(solver, domain_factory)

print("***Without verbosity")
solver = CGP("TEMP_CGP", n_it=2, verbose=False)
GymDomain.solve_with(solver, domain_factory)

```