### PR TITLE
Update python allowed: [3.8 ; 3.11]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       python_version: ${{ steps.generate-matrix.outputs.python_version }}
+      python_version_per_os: ${{ steps.generate-matrix.outputs.python_version_per_os }}
       build: ${{ steps.generate-matrix.outputs.build}}
       test: ${{ steps.generate-matrix.outputs.test}}
       do_macos: ${{ steps.generate-matrix.outputs.do_macos}}
@@ -81,6 +82,13 @@ jobs:
                   build_doc = "false"
           oses = ["macos", "ubuntu", "windows"]
           build_dict = {os : [k for k in build if k.startswith(os)] for os in oses}
+          python_version_per_os = {os: python_version for os in oses}
+          # remove python 3.11 for windows: dependency conflict from pyarrow prevent testing the wheel windows python 3.11
+          python_version_per_os["windows"] = [v for v in python_version if v != "3.11"]
+          # update build_dict by removing os without any python version
+          for os in build_dict:
+              if len(python_version_per_os[os]) == 0:
+                    build_dict[os] = []
 
           with open(environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"build={build_dict}\n")
@@ -89,6 +97,8 @@ jobs:
               for os in oses:
                   f.write(f"do_{os}={'true' if len(build_dict[os]) > 0 else 'false'}\n")
               f.write(f"python_version={python_version}\n")
+              f.write(f"python_version_per_os={python_version_per_os}\n")
+
 
   lint-sources:
     runs-on: ubuntu-latest
@@ -113,7 +123,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).windows }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).windows }}
       fail-fast: false
     defaults:
       run:
@@ -192,7 +202,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).macos }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).macos }}
       fail-fast: false
     defaults:
       run:
@@ -293,7 +303,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).ubuntu }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).ubuntu }}
       fail-fast: false
     defaults:
       run:
@@ -397,7 +407,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).windows }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).windows }}
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -481,7 +491,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).macos }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).macos }}
       fail-fast: true
     runs-on: ${{ matrix.os }}
     env:
@@ -564,7 +574,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).ubuntu }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).ubuntu }}
       fail-fast: true
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           from os import environ
 
-          python_version = ["3.7", "3.8", "3.9", "3.10"]
+          python_version = ["3.8", "3.9", "3.10", "3.11"]
           build = [ "macos-latest", "ubuntu-latest", "windows-latest" ]
           test = [ "macos-11", "macos-12", "ubuntu-22.04", "ubuntu-20.04", "windows-2019", "windows-2022"]
           build_doc = "true"
@@ -48,7 +48,7 @@ jobs:
           if "${{ github.event_name }}" != "schedule":
               to_bool = lambda s: True if s == "true" else False
               python_filter = {
-                  '3.7' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.7]') }}"),
+                  '3.11' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.11]') }}"),
                   '3.8' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.8]') }}"),
                   '3.9' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.9]') }}"),
                   '3.10' : to_bool("${{ contains(github.event.head_commit.message, '[ci: python-3.10]') }}"),
@@ -652,7 +652,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -723,7 +723,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       python_version: ${{ steps.generate-matrix.outputs.python_version }}
+      python_version_per_os: ${{ steps.generate-matrix.outputs.python_version_per_os }}
       build: ${{ steps.generate-matrix.outputs.build}}
       test: ${{ steps.generate-matrix.outputs.test}}
       deploy_test_pypi: ${{ steps.generate-matrix.outputs.deploy_test_pypi}}
@@ -31,7 +32,8 @@ jobs:
           build_dict = { "macos":["macos-11"], "ubuntu":["ubuntu-latest"], "windows":["windows-latest"] }
           test_dict = { "macos":["macos-12", "macos-11"], "ubuntu":["ubuntu-22.04", "ubuntu-20.04"], "windows":["windows-2019", "windows-2022" ]}
           deploy_test_pypi = "true"
-
+          python_version_per_os = {os: python_version for os in build_dict}
+          # remove python 3.11 for windows: dependency conflict from pyarrow prevent testing the wheel windows python 3.11          python_version_per_os["windows"] = [v for v in python_version if v != "3.11"]
           if "${{ contains(github.event.head_commit.message, '[ci: skip-deploy-test-pypi]') }}" == "true":
               deploy_test_pypi = "false"
 
@@ -39,6 +41,7 @@ jobs:
               f.write(f"build={build_dict}\n")
               f.write(f"test={test_dict}\n")
               f.write(f"python_version={python_version}\n")
+              f.write(f"python_version_per_os={python_version_per_os}\n")
               f.write(f"deploy_test_pypi={deploy_test_pypi}\n")
 
   lint-sources:
@@ -63,7 +66,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).windows }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).windows }}
       fail-fast: false
     defaults:
       run:
@@ -141,7 +144,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).macos }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).macos }}
       fail-fast: false
     defaults:
       run:
@@ -222,7 +225,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.build).ubuntu }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).ubuntu }}
       fail-fast: false
     defaults:
       run:
@@ -314,7 +317,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).windows }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).windows }}
         compiler: [gnu]
       fail-fast: true
     runs-on: ${{ matrix.os }}
@@ -398,7 +401,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).macos }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).macos }}
       fail-fast: true
     runs-on: ${{ matrix.os }}
     env:
@@ -481,7 +484,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.test).ubuntu }}
-        python-version: ${{ fromJSON(needs.setup.outputs.python_version) }}
+        python-version: ${{ fromJSON(needs.setup.outputs.python_version_per_os).ubuntu }}
       fail-fast: true
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           from os import environ
 
-          python_version = ["3.7", "3.8", "3.9", "3.10"]
+          python_version = ["3.8", "3.9", "3.10", "3.11"]
           build_dict = { "macos":["macos-11"], "ubuntu":["ubuntu-latest"], "windows":["windows-latest"] }
           test_dict = { "macos":["macos-12", "macos-11"], "ubuntu":["ubuntu-22.04", "ubuntu-20.04"], "windows":["windows-2019", "windows-2022" ]}
           deploy_test_pypi = "true"
@@ -616,7 +616,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCS_VERSION_PATH: /
-      python_version: "3.7"
+      python_version: "3.8"
 
     steps:
       - name: Get scikit-decide release version and update online docs path

--- a/poetry.lock
+++ b/poetry.lock
@@ -62,9 +62,6 @@ files = [
     {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
 ]
 
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-
 [package.extras]
 cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
 dev = ["attrs[docs,tests]", "pre-commit"]
@@ -273,7 +270,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "clingo"
@@ -1033,7 +1029,7 @@ name = "importlib-metadata"
 version = "6.7.0"
 description = "Read metadata from Python packages"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
@@ -1041,7 +1037,6 @@ files = [
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -1211,11 +1206,9 @@ files = [
 
 [package.dependencies]
 attrs = ">=17.4.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\""}
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
@@ -1379,9 +1372,6 @@ files = [
     {file = "kiwisolver-1.4.5.tar.gz", hash = "sha256:e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
 [[package]]
 name = "llvmlite"
 version = "0.39.1"
@@ -1484,7 +1474,6 @@ files = [
 
 [package.dependencies]
 mdurl = ">=0.1,<1.0"
-typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark"]
@@ -1762,7 +1751,6 @@ files = [
 
 [package.dependencies]
 fastjsonschema = "*"
-importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.8\""}
 jsonschema = ">=2.6"
 jupyter-core = "*"
 traitlets = ">=5.1"
@@ -2249,9 +2237,6 @@ files = [
     {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
 
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
@@ -2637,7 +2622,6 @@ files = [
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -3110,35 +3094,42 @@ test = ["asv", "codecov", "flake8", "matplotlib (>=3.0.3)", "pooch (>=1.3.0)", "
 
 [[package]]
 name = "scipy"
-version = "1.6.1"
-description = "SciPy: Scientific Library for Python"
+version = "1.9.3"
+description = "Fundamental algorithms for scientific computing in Python"
 category = "main"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "scipy-1.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a15a1f3fc0abff33e792d6049161b7795909b40b97c6cc2934ed54384017ab76"},
-    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e79570979ccdc3d165456dd62041d9556fb9733b86b4b6d818af7a0afc15f092"},
-    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a423533c55fec61456dedee7b6ee7dce0bb6bfa395424ea374d25afa262be261"},
-    {file = "scipy-1.6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:33d6b7df40d197bdd3049d64e8e680227151673465e5d85723b3b8f6b15a6ced"},
-    {file = "scipy-1.6.1-cp37-cp37m-win32.whl", hash = "sha256:6725e3fbb47da428794f243864f2297462e9ee448297c93ed1dcbc44335feb78"},
-    {file = "scipy-1.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:5fa9c6530b1661f1370bcd332a1e62ca7881785cc0f80c0d559b636567fab63c"},
-    {file = "scipy-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bd50daf727f7c195e26f27467c85ce653d41df4358a25b32434a50d8870fc519"},
-    {file = "scipy-1.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f46dd15335e8a320b0fb4685f58b7471702234cba8bb3442b69a3e1dc329c345"},
-    {file = "scipy-1.6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0e5b0ccf63155d90da576edd2768b66fb276446c371b73841e3503be1d63fb5d"},
-    {file = "scipy-1.6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2481efbb3740977e3c831edfd0bd9867be26387cacf24eb5e366a6a374d3d00d"},
-    {file = "scipy-1.6.1-cp38-cp38-win32.whl", hash = "sha256:68cb4c424112cd4be886b4d979c5497fba190714085f46b8ae67a5e4416c32b4"},
-    {file = "scipy-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:5f331eeed0297232d2e6eea51b54e8278ed8bb10b099f69c44e2558c090d06bf"},
-    {file = "scipy-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0c8a51d33556bf70367452d4d601d1742c0e806cd0194785914daf19775f0e67"},
-    {file = "scipy-1.6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:83bf7c16245c15bc58ee76c5418e46ea1811edcc2e2b03041b804e46084ab627"},
-    {file = "scipy-1.6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:794e768cc5f779736593046c9714e0f3a5940bc6dcc1dba885ad64cbfb28e9f0"},
-    {file = "scipy-1.6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5da5471aed911fe7e52b86bf9ea32fb55ae93e2f0fac66c32e58897cfb02fa07"},
-    {file = "scipy-1.6.1-cp39-cp39-win32.whl", hash = "sha256:8e403a337749ed40af60e537cc4d4c03febddcc56cd26e774c9b1b600a70d3e4"},
-    {file = "scipy-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5193a098ae9f29af283dcf0041f762601faf2e595c0db1da929875b7570353f"},
-    {file = "scipy-1.6.1.tar.gz", hash = "sha256:c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11"},
+    {file = "scipy-1.9.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1884b66a54887e21addf9c16fb588720a8309a57b2e258ae1c7986d4444d3bc0"},
+    {file = "scipy-1.9.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:83b89e9586c62e787f5012e8475fbb12185bafb996a03257e9675cd73d3736dd"},
+    {file = "scipy-1.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a72d885fa44247f92743fc20732ae55564ff2a519e8302fb7e18717c5355a8b"},
+    {file = "scipy-1.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d01e1dd7b15bd2449c8bfc6b7cc67d630700ed655654f0dfcf121600bad205c9"},
+    {file = "scipy-1.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:68239b6aa6f9c593da8be1509a05cb7f9efe98b80f43a5861cd24c7557e98523"},
+    {file = "scipy-1.9.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b41bc822679ad1c9a5f023bc93f6d0543129ca0f37c1ce294dd9d386f0a21096"},
+    {file = "scipy-1.9.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:90453d2b93ea82a9f434e4e1cba043e779ff67b92f7a0e85d05d286a3625df3c"},
+    {file = "scipy-1.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c06e62a390a9167da60bedd4575a14c1f58ca9dfde59830fc42e5197283dab"},
+    {file = "scipy-1.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abaf921531b5aeaafced90157db505e10345e45038c39e5d9b6c7922d68085cb"},
+    {file = "scipy-1.9.3-cp311-cp311-win_amd64.whl", hash = "sha256:06d2e1b4c491dc7d8eacea139a1b0b295f74e1a1a0f704c375028f8320d16e31"},
+    {file = "scipy-1.9.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5a04cd7d0d3eff6ea4719371cbc44df31411862b9646db617c99718ff68d4840"},
+    {file = "scipy-1.9.3-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:545c83ffb518094d8c9d83cce216c0c32f8c04aaf28b92cc8283eda0685162d5"},
+    {file = "scipy-1.9.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d54222d7a3ba6022fdf5773931b5d7c56efe41ede7f7128c7b1637700409108"},
+    {file = "scipy-1.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cff3a5295234037e39500d35316a4c5794739433528310e117b8a9a0c76d20fc"},
+    {file = "scipy-1.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:2318bef588acc7a574f5bfdff9c172d0b1bf2c8143d9582e05f878e580a3781e"},
+    {file = "scipy-1.9.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d644a64e174c16cb4b2e41dfea6af722053e83d066da7343f333a54dae9bc31c"},
+    {file = "scipy-1.9.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:da8245491d73ed0a994ed9c2e380fd058ce2fa8a18da204681f2fe1f57f98f95"},
+    {file = "scipy-1.9.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4db5b30849606a95dcf519763dd3ab6fe9bd91df49eba517359e450a7d80ce2e"},
+    {file = "scipy-1.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c68db6b290cbd4049012990d7fe71a2abd9ffbe82c0056ebe0f01df8be5436b0"},
+    {file = "scipy-1.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:5b88e6d91ad9d59478fafe92a7c757d00c59e3bdc3331be8ada76a4f8d683f58"},
+    {file = "scipy-1.9.3.tar.gz", hash = "sha256:fbc5c05c85c1a02be77b1ff591087c83bc44579c6d2bd9fb798bb64ea5e1a027"},
 ]
 
 [package.dependencies]
-numpy = ">=1.16.5"
+numpy = ">=1.18.5,<1.26.0"
+
+[package.extras]
+dev = ["flake8", "mypy", "pycodestyle", "typing_extensions"]
+doc = ["matplotlib (>2)", "numpydoc", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-panels (>=0.5.2)", "sphinx-tabs"]
+test = ["asv", "gmpy2", "mpmath", "pytest", "pytest-cov", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
 name = "seaborn"
@@ -3156,7 +3147,6 @@ files = [
 matplotlib = ">=3.1,<3.6.1 || >3.6.1"
 numpy = ">=1.17,<1.24.0 || >1.24.0"
 pandas = ">=0.25"
-typing_extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["flake8", "flit", "mypy", "pandas-stubs", "pre-commit", "pytest", "pytest-cov", "pytest-xdist"]
@@ -3401,7 +3391,6 @@ matplotlib = "*"
 numpy = ">=1.20"
 pandas = "*"
 torch = ">=1.11"
-typing-extensions = {version = ">=4.0,<5", markers = "python_version < \"3.8.0\""}
 
 [package.extras]
 docs = ["sphinx (>=5.3,<7.0)", "sphinx-autobuild", "sphinx-autodoc-typehints", "sphinx-copybutton", "sphinx-rtd-theme", "sphinxcontrib.spelling"]
@@ -3582,7 +3571,7 @@ name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
@@ -3746,5 +3735,5 @@ solvers = ["discrete-optimization", "gymnasium", "joblib", "numpy", "ray", "stab
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "5310ffa31772e1b0d4cd29e1b60618ce43a06180b085c584036c1271031ba6f3"
+python-versions = "^3.8"
+content-hash = "5c0bc5b4d5e77b3da538bf377e1db6fa98d2d4ac56c21c792437e5443dbf94da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,10 @@ format-jinja = """
 files = ["skdecide/__init__.py"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 pynng = ">=0.6.2"
 pathos = ">=0.2.7"
+scipy = {version = ">=1.9.2", optional = true}
 simplejson = {version = ">=3.17.2", optional = true}
 gymnasium = {version = ">=0.28.1", optional = true}
 numpy = {version = ">=1.20.1", optional = true}

--- a/scripts/Dockerfile_x86_64_dev
+++ b/scripts/Dockerfile_x86_64_dev
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64
+ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64:latest
 
 FROM $BASE_IMAGE as build
 


### PR DESCRIPTION
We start now from 3.8 and end with 3.11.
We build a wheel for 3.11, except on windows. The reason for this exception is that there is dependency conflicts when installing scikit-decide[all] on windows python3.11 (seemingly due to pyarrow) and thus we could not test the generated wheel.