### PR TITLE
Update list of binderhubs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -925,7 +925,6 @@ jobs:
       # only if a nightly release occured
       if: ${{ steps.asset.outputs.result != '' }}
       run: |
-        bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/${GITHUB_REPOSITORY}/binder
         bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/${GITHUB_REPOSITORY}/binder
-        bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/${GITHUB_REPOSITORY}/binder
-        bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/${GITHUB_REPOSITORY}/binder
+        bash scripts/trigger_binder.sh https://ovh2.mybinder.org/build/gh/${GITHUB_REPOSITORY}/binder
+        bash scripts/trigger_binder.sh https://notebooks.gesis.org/binder/build/gh/${GITHUB_REPOSITORY}/binder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -657,6 +657,7 @@ jobs:
       - name: Trigger a build on each BinderHub deployments in the mybinder.org federation
         run: |
           bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
+          bash scripts/trigger_binder.sh https://ovh2.mybinder.org/build/gh/${GITHUB_REPOSITORY}/binder
           bash scripts/trigger_binder.sh https://notebooks.gesis.org/binder/build/gh/${GITHUB_REPOSITORY}/${BINDER_RELEASE_ENV_SHA1}
 
       - name: Set env variables for github+binder links in doc


### PR DESCRIPTION
Only ovh and gesis now.
The upload-nightly job was reported as failed beacause of the outdated lists of binderhub.
