### PR TITLE
Remove virtual display for gymnasium tutorial on binder

### DIFF
--- a/notebooks/12_gym_tuto.ipynb
+++ b/notebooks/12_gym_tuto.ipynb
@@ -37,7 +37,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "from time import sleep\n",
     "from typing import Callable, Optional\n",
     "\n",
@@ -59,26 +58,6 @@
     "\n",
     "# choose standard matplolib inline backend to render plots\n",
     "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When running this notebook on remote servers like with Colab or Binder, rendering of gymnasium environment will fail as no actual display device exists. Thus we need to start a virtual display to make it work."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if \"DISPLAY\" not in os.environ:\n",
-    "    import pyvirtualdisplay\n",
-    "\n",
-    "    _display = pyvirtualdisplay.Display(visible=False, size=(1400, 900))\n",
-    "    _display.start()"
    ]
   },
   {
@@ -906,7 +885,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.10.11"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Due to changes in gymnasium environments rendering, we do not need anymore virtual display. Worse, this would make now the kernel die on binder.

Fix #290.