### PR TITLE
Skip test_up_bridge_solver_numeric on MacOS

### DIFF
--- a/tests/solvers/python/test_up_bridge_solver.py
+++ b/tests/solvers/python/test_up_bridge_solver.py
@@ -80,8 +80,8 @@ def test_up_bridge_solver_classic():
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 10) or platform.system() == "Windows",
-    reason="requires python3.10 or higher and any OS different from Windows",
+    sys.version_info < (3, 10) or platform.system() in ("Windows", "Darwin"),
+    reason="requires python3.10 or higher and any OS different from Windows or MacOS",
 )
 def test_up_bridge_solver_numeric():
     noexcept = True


### PR DESCRIPTION
This is temporary because of a crash during UP `solve()`.