### PR TITLE
Split tests using the c++ library from others to avoid openmp conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,8 +476,9 @@ jobs:
           ${{ env.minizinc_config_cmdline }}
           # test minizinc
           python -c "import minizinc; print(minizinc.default_driver.minizinc_version); minizinc.Solver.lookup('gecode')"
-          # run pytest
-          pytest -v -s tests
+          # run pytest, split tests using cpp scikit-decide library from others to avoid openmp versions conflicts
+          pytest -v -s tests/*/cpp
+          pytest -v -s --ignore-glob tests/*/cpp
 
   test-macos:
     needs: [build-macos, setup]
@@ -552,8 +553,9 @@ jobs:
           ${{ env.minizinc_config_cmdline }}
           # test minizinc
           python -c "import minizinc; print(minizinc.default_driver.minizinc_version); minizinc.Solver.lookup('gecode')"
-          # run pytest
-          pytest -v -s tests
+          # run pytest, split tests using cpp scikit-decide library from others to avoid openmp versions conflicts
+          pytest -v -s tests/*/cpp
+          pytest -v -s --ignore-glob tests/*/cpp
 
   test-ubuntu:
     needs: [build-ubuntu, setup]
@@ -627,8 +629,9 @@ jobs:
           ${{ env.minizinc_config_cmdline }}
           # test minizinc
           python -c "import minizinc; print(minizinc.default_driver.minizinc_version); minizinc.Solver.lookup('gecode')"
-          # run pytest
-          pytest -v -s tests
+          # run pytest, split tests using cpp scikit-decide library from others to avoid openmp versions conflicts
+          pytest -v -s tests/*/cpp
+          pytest -v -s --ignore-glob tests/*/cpp
 
       - name: Test python block codes from guide
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,8 +386,9 @@ jobs:
           ${{ env.minizinc_config_cmdline }}
           # test minizinc
           python -c "import minizinc; print(minizinc.default_driver.minizinc_version); minizinc.Solver.lookup('gecode')"
-          # run pytest
-          pytest -v -s tests
+          # run pytest, split tests using cpp scikit-decide library from others to avoid openmp versions conflicts
+          pytest -v -s tests/*/cpp
+          pytest -v -s --ignore-glob tests/*/cpp
 
   test-macos:
     needs: [build-macos, build-ubuntu, build-windows, setup]
@@ -462,8 +463,9 @@ jobs:
           ${{ env.minizinc_config_cmdline }}
           # test minizinc
           python -c "import minizinc; print(minizinc.default_driver.minizinc_version); minizinc.Solver.lookup('gecode')"
-          # run pytest
-          pytest -v -s tests
+          # run pytest, split tests using cpp scikit-decide library from others to avoid openmp versions conflicts
+          pytest -v -s tests/*/cpp
+          pytest -v -s --ignore-glob tests/*/cpp
 
   test-ubuntu:
     needs: [build-macos, build-ubuntu, build-windows, setup]
@@ -536,8 +538,9 @@ jobs:
           ${{ env.minizinc_config_cmdline }}
           # test minizinc
           python -c "import minizinc; print(minizinc.default_driver.minizinc_version); minizinc.Solver.lookup('gecode')"
-          # run pytest
-          pytest -v -s tests
+          # run pytest, split tests using cpp scikit-decide library from others to avoid openmp versions conflicts
+          pytest -v -s tests/*/cpp
+          pytest -v -s --ignore-glob tests/*/cpp
 
   upload:
     needs: [test-ubuntu, test-macos, test-windows]


### PR DESCRIPTION
Some python dependencies (like tensorflow) do not use the same version of openmp as the one used by the scikit-decide c++ library. So issue can occur, in particular on macOS. We split the tests in 2 parts to avoid this.