### PR TITLE
Fix release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
           deploy_test_pypi = "true"
           python_version_per_os = {os: python_version for os in build_dict}
           # remove python 3.11 for windows: dependency conflict from pyarrow prevent testing the wheel windows python 3.11          python_version_per_os["windows"] = [v for v in python_version if v != "3.11"]
+          python_version_per_os["windows"] = [v for v in python_version if v != "3.11"]
+
           if "${{ contains(github.event.head_commit.message, '[ci: skip-deploy-test-pypi]') }}" == "true":
               deploy_test_pypi = "false"
 


### PR DESCRIPTION
We do not want to publish a windows 3.11 wheel because of a dependencies conflict preventing to test it, as explained in commit 4767f4e.