### PR TITLE
Squash gh-pages into a single commit when deploying doc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -760,6 +760,7 @@ jobs:
           folder: docs/.vuepress/dist # The folder the action should deploy.
           target-folder: / # The folder the action should deploy to.
           commit-message: publish documentation
+          single-commit: true
           clean-exclude: |
             "version/*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -709,6 +709,7 @@ jobs:
           folder: docs/.vuepress/dist # The folder the action should deploy.
           target-folder: ${{ env.DOCS_VERSION_PATH }} # The folder the action should deploy to.
           commit-message: publish documentation
+          single-commit: true
           clean: false # Releasing a new version is about creating a new directory, so we don't want to clean up the root.
 
   delete-nightly-release:


### PR DESCRIPTION
To avoid a (very) long series of similar commits "publish documentation", we use the option single-commit to squash everything in a single commit on gh-pages.

The workflow has been tested on my fork by setting master to this commit, and also tagging it in order to simulate a release.
The documentation is still available on https://nhuet.github.io/scikit-decide (dev doc),  https://nhuet.github.io/scikit-decide/version/0.0.51 (new fake release), https://nhuet.github.io/scikit-decide/version/0.0.10 (previous fake release, still there).
