### PR TITLE
Update binder environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
-name: nb-skdecide092-py38
+name: nb-skdecide-py310
 channels:
   - pytorch
   - defaults
 dependencies:
   - cartopy>=0.21
-  - python=3.8
+  - python=3.10
   - pip
   - pytorch::cpuonly
   - pytorch::pytorch

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
     - PyOpenGL-accelerate
     - PyOpenGL
     - xarray
+    - gymnasium[classic-control]==0.28.1


### PR DESCRIPTION
- add gymnasium[classic-control] for gymnasium notebook
- use python 3.10 to be able to use cartopy and unified-planning