### PR TITLE
Remove `Solver` intermediate private methods not to be overriden

### DIFF
--- a/examples/gym_jsbsim_greedy.py
+++ b/examples/gym_jsbsim_greedy.py
@@ -116,7 +116,7 @@ class GreedyPlanner(Solver, DeterministicPolicies, Utilities):
         lat = self._domain._gym_env.sim.get_property_value(prp.position_lat_geod_deg)
         self._current_pos = (lat, lon)
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self._init_solve(domain_factory)
 
     def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/aostar/aostar.py
+++ b/skdecide/hub/solver/aostar/aostar.py
@@ -104,7 +104,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/ars/ars.py
+++ b/skdecide/hub/solver/ars/ars.py
@@ -158,7 +158,7 @@ class AugmentedRandomSearch(Solver, Policies, Restorable):
         else:
             return 2 * np.random.random_sample() - 1
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
 
         self.env = domain_factory()
         np.random.seed(0)

--- a/skdecide/hub/solver/astar/astar.py
+++ b/skdecide/hub/solver/astar/astar.py
@@ -95,7 +95,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/bfws/bfws.py
+++ b/skdecide/hub/solver/bfws/bfws.py
@@ -108,7 +108,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/cgp/cgp.py
+++ b/skdecide/hub/solver/cgp/cgp.py
@@ -271,7 +271,7 @@ class CGPWrapper(Solver, DeterministicPolicies):
 
         return valide_action_space and validate_observation_space
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         domain = domain_factory()
 
         evaluator = SkDecideEvaluator(domain)

--- a/skdecide/hub/solver/do_solver/do_solver_scheduling.py
+++ b/skdecide/hub/solver/do_solver/do_solver_scheduling.py
@@ -186,7 +186,7 @@ class DOSolver(Solver, DeterministicPolicies):
 
         return smap
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self.domain = domain_factory()
         self.do_domain = build_do_domain(self.domain)
         solvers = build_solver(solving_method=self.method, do_domain=self.do_domain)

--- a/skdecide/hub/solver/gphh/gphh.py
+++ b/skdecide/hub/solver/gphh/gphh.py
@@ -543,7 +543,7 @@ class GPHH(Solver, DeterministicPolicies):
     #         else:
     #             self.reference_makespans[td] = reference_makespans[td_name]
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self.domain = domain_factory()
 
         tournament_ratio = self.params_gphh.tournament_ratio

--- a/skdecide/hub/solver/ilaostar/ilaostar.py
+++ b/skdecide/hub/solver/ilaostar/ilaostar.py
@@ -101,7 +101,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/iw/iw.py
+++ b/skdecide/hub/solver/iw/iw.py
@@ -98,7 +98,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/lazy_astar/lazy_astar.py
+++ b/skdecide/hub/solver/lazy_astar/lazy_astar.py
@@ -61,7 +61,7 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities):
         self._values = {}
         self._plan = []
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self._domain = domain_factory()
 
         def extender(node, label, explored):

--- a/skdecide/hub/solver/lrtastar/lrtastar.py
+++ b/skdecide/hub/solver/lrtastar/lrtastar.py
@@ -77,7 +77,7 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities):
         self.heuristic_changed = False
         self._policy = {}
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self._domain = domain_factory()
         self.values = {}
         iteration = 0

--- a/skdecide/hub/solver/lrtdp/lrtdp.py
+++ b/skdecide/hub/solver/lrtdp/lrtdp.py
@@ -131,7 +131,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/mahd/mahd.py
+++ b/skdecide/hub/solver/mahd/mahd.py
@@ -74,7 +74,7 @@ class MAHD(Solver, DeterministicPolicies, Utilities):
             a: {} for a in self._multiagent_domain.get_agents()
         }
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self._multiagent_domain_class.solve_with(
             solver=self._multiagent_solver, domain_factory=domain_factory
         )

--- a/skdecide/hub/solver/martdp/martdp.py
+++ b/skdecide/hub/solver/martdp/martdp.py
@@ -147,7 +147,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/maxent_irl/maxent_irl.py
+++ b/skdecide/hub/solver/maxent_irl/maxent_irl.py
@@ -139,7 +139,7 @@ class MaxentIRL(Solver, Policies, Restorable):
                 demonstrations[x][y][1] = rawFile["actions"][index]
                 index += 1
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self.env = domain_factory()
         if self.q_table is not None:
             return

--- a/skdecide/hub/solver/mcts/mcts.py
+++ b/skdecide/hub/solver/mcts/mcts.py
@@ -170,7 +170,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:
@@ -293,8 +293,8 @@ try:
             self._action_choice_noise = action_choice_noise
             self._heuristic_records = {}
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
-            super()._solve_domain(domain_factory=domain_factory)
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
+            super()._solve(domain_factory=domain_factory)
             self._heuristic_records = {}
 
         def _value_heuristic(

--- a/skdecide/hub/solver/pile_policy/pile_policy.py
+++ b/skdecide/hub/solver/pile_policy/pile_policy.py
@@ -35,7 +35,7 @@ class PilePolicy(Solver, DeterministicPolicies):
     def __init__(self, greedy_method: GreedyChoice = GreedyChoice.MOST_SUCCESSORS):
         self.greedy_method = greedy_method
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self.domain = domain_factory()
         self.graph = self.domain.graph
         self.nx_graph: nx.DiGraph = self.graph.to_networkx()

--- a/skdecide/hub/solver/pomcp/pomcp.py
+++ b/skdecide/hub/solver/pomcp/pomcp.py
@@ -56,7 +56,7 @@ class POMCP(Solver, DeterministicPolicies):
         # for the range of possible cost values.
         self._VLV = 100 * self._max_depth
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self._domain = domain_factory()
         self._initial_belief = []
         d = self._domain.get_initial_state_distribution()

--- a/skdecide/hub/solver/ray_rllib/ray_rllib.py
+++ b/skdecide/hub/solver/ray_rllib/ray_rllib.py
@@ -99,7 +99,7 @@ class RayRLlib(Solver, Policies, Restorable):
                 isinstance(o, GymSpace) for o in domain.get_observation_space().values()
             )
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         # Reuse algo if possible (enables further learning)
         if not hasattr(self, "_algo"):
             self._init_algo(domain_factory)

--- a/skdecide/hub/solver/riw/riw.py
+++ b/skdecide/hub/solver/riw/riw.py
@@ -128,7 +128,7 @@ try:
             )
             self._solver.clear()
 
-        def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+        def _solve(self, domain_factory: Callable[[], D]) -> None:
             self._init_solve(domain_factory)
 
         def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:

--- a/skdecide/hub/solver/simple_greedy/simple_greedy.py
+++ b/skdecide/hub/solver/simple_greedy/simple_greedy.py
@@ -21,7 +21,7 @@ class SimpleGreedy(DeterministicPolicySolver):
     def _check_domain_additional(cls, domain: D) -> bool:
         return isinstance(domain.get_action_space(), EnumerableSpace)
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self._domain = (
             domain_factory()
         )  # no further solving code required here since everything is computed online

--- a/skdecide/hub/solver/stable_baselines/stable_baselines.py
+++ b/skdecide/hub/solver/stable_baselines/stable_baselines.py
@@ -57,7 +57,7 @@ class StableBaseline(Solver, Policies, Restorable):
             domain.get_observation_space(), GymSpace
         )
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         # TODO: improve code for parallelism
         #  (https://stable-baselines3.readthedocs.io/en/master/guide/examples.html
         #  #multiprocessing-unleashing-the-power-of-vectorized-environments)?

--- a/skdecide/hub/solver/up/up.py
+++ b/skdecide/hub/solver/up/up.py
@@ -50,7 +50,7 @@ class UPSolver(Solver, DeterministicPolicies, Utilities):
         self._policy = {}
         self._values = {}
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve(self, domain_factory: Callable[[], D]) -> None:
         self._domain = domain_factory()
         problem = self._domain._problem
         om_params = (

--- a/skdecide/solvers.py
+++ b/skdecide/solvers.py
@@ -46,17 +46,6 @@ class Solver:
         # Returns
         A list of classes to inherit from.
         """
-        return cls._get_domain_requirements()
-
-    @classmethod
-    def _get_domain_requirements(cls) -> List[type]:
-        """Get domain requirements for this solver class to be applicable.
-
-        Domain requirements are classes from the #skdecide.builders.domain package that the domain needs to inherit from.
-
-        # Returns
-        A list of classes to inherit from.
-        """
 
         def is_domain_builder(
             cls,
@@ -101,25 +90,8 @@ class Solver:
         # Returns
         True if the domain is compliant with the solver type (False otherwise).
         """
-        return cls._check_domain(domain)
-
-    @classmethod
-    def _check_domain(cls, domain: Domain) -> bool:
-        """Check whether a domain is compliant with this solver type.
-
-        By default, #Solver._check_domain() provides some boilerplate code and internally
-        calls #Solver._check_domain_additional() (which returns True by default but can be overridden to define specific
-        checks in addition to the "domain requirements"). The boilerplate code automatically checks whether all domain
-        requirements are met.
-
-        # Parameters
-        domain: The domain to check.
-
-        # Returns
-        True if the domain is compliant with the solver type (False otherwise).
-        """
         check_requirements = all(
-            isinstance(domain, req) for req in cls._get_domain_requirements()
+            isinstance(domain, req) for req in cls.get_domain_requirements()
         )
         return check_requirements and cls._check_domain_additional(domain)
 
@@ -128,7 +100,7 @@ class Solver:
         """Check whether the given domain is compliant with the specific requirements of this solver type (i.e. the
         ones in addition to "domain requirements").
 
-        This is a helper function called by default from #Solver._check_domain(). It focuses on specific checks, as
+        This is a helper function called by default from #Solver.check_domain(). It focuses on specific checks, as
         opposed to taking also into account the domain requirements for the latter.
 
         # Parameters
@@ -168,33 +140,18 @@ class Solver:
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
         """
-        return self._solve(domain_factory)
-
-    def _solve(self, domain_factory: Callable[[], Domain]) -> None:
-        """Run the solving process.
-
-        By default, #Solver._solve() provides some boilerplate code and internally calls #Solver._solve_domain(). The
-        boilerplate code transforms the domain factory to auto-cast the new domains to the level expected by the solver.
-
-        # Parameters
-        domain_factory: A callable with no argument returning the domain to solve (can be just a domain class).
-
-        !!! tip
-            The nature of the solutions produced here depends on other solver's characteristics like
-            #policy and #assessibility.
-        """
 
         def cast_domain_factory():
             domain = domain_factory()
             autocast_all(domain, domain, self.T_domain)
             return domain
 
-        return self._solve_domain(cast_domain_factory)
+        return self._solve(cast_domain_factory)
 
-    def _solve_domain(self, domain_factory: Callable[[], T_domain]) -> None:
+    def _solve(self, domain_factory: Callable[[], T_domain]) -> None:
         """Run the solving process.
 
-        This is a helper function called by default from #Solver._solve(), the difference being that the domain factory
+        This is a helper function called by default from #Solver.solve(), the difference being that the domain factory
         here returns domains auto-cast to the level expected by the solver.
 
         # Parameters

--- a/skdecide/solvers.py
+++ b/skdecide/solvers.py
@@ -124,7 +124,7 @@ class Solver:
         return check_requirements and cls._check_domain_additional(domain)
 
     @classmethod
-    def _check_domain_additional(cls, domain: D) -> bool:
+    def _check_domain_additional(cls, domain: Domain) -> bool:
         """Check whether the given domain is compliant with the specific requirements of this solver type (i.e. the
         ones in addition to "domain requirements").
 
@@ -191,7 +191,7 @@ class Solver:
 
         return self._solve_domain(cast_domain_factory)
 
-    def _solve_domain(self, domain_factory: Callable[[], D]) -> None:
+    def _solve_domain(self, domain_factory: Callable[[], T_domain]) -> None:
         """Run the solving process.
 
         This is a helper function called by default from #Solver._solve(), the difference being that the domain factory


### PR DESCRIPTION
The convention is the library is that the user has to override/implement
methods whose names are starting with "_".

The methods wihtout the leading "_" are calling the former, generally by
adding autocast boilerplate.

In Solver class, some methods are duplicated without this purpose in
mind, we simplify it here:

- `_get_domain_requirements()` -> `get_domain_requirements()`
- `_check_domain()` -> `check_domain()`, which continue calling
  `_check_domain_additional()` to be overriden
- `_solve()` -> `solve()`, and `_solve_domain()` -> `_solve()`, so that `solve()` autocast
  `domain_factory` and then call `_solve()` to be implemented