### PR TITLE
Add getters for the computed plan or policy computed by each solver

### DIFF
--- a/skdecide/hub/solver/ilaostar/ilaostar.py
+++ b/skdecide/hub/solver/ilaostar/ilaostar.py
@@ -138,6 +138,7 @@ try:
             D.T_agent[D.T_observation],
             Tuple[D.T_agent[D.T_concurrency[D.T_event]], float],
         ]:
+            """Return the computed policy."""
             return self._solver.get_policy()
 
 except ImportError:

--- a/skdecide/hub/solver/lazy_astar/lazy_astar.py
+++ b/skdecide/hub/solver/lazy_astar/lazy_astar.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from heapq import heappop, heappush
 from itertools import count
-from typing import Callable, Optional
+from typing import Callable, Dict, List, Optional
 
 from skdecide import Domain, Solver, Value
 from skdecide.builders.domain import (
@@ -57,7 +57,15 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         self._verbose = verbose
         self._render = render
         self._values = {}
-        self._plan = []
+        self._plan: List[D.T_event] = []
+
+    def get_plan(self) -> List[D.T_event]:
+        """Return the computed plan."""
+        return self._plan
+
+    def get_policy(self) -> Dict[D.T_observation, Optional[D.T_event]]:
+        """Return the computed policy."""
+        return self._policy
 
     def _init_solve(self, domain_factory: Callable[[], Domain]) -> None:
         """Initialize solver before calling `solve_from()`
@@ -186,7 +194,7 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
                         lbl,
                     ),
                 )
-        self._policy = {}
+        self._policy: Dict[D.T_observation, Optional[D.T_event]] = {}
         for node, label in path:
             self._policy[node] = label["action"] if label is not None else None
             self._values[node] = estim_total - enqueued[node][0]

--- a/skdecide/hub/solver/lrtastar/lrtastar.py
+++ b/skdecide/hub/solver/lrtastar/lrtastar.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable, Dict, List, Optional
 
 from skdecide import Domain, Solver, Value
 from skdecide.builders.domain import (
@@ -44,7 +44,7 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         return self._policy.get(observation, None)
 
     def _is_policy_defined_for(self, observation: D.T_agent[D.T_observation]) -> bool:
-        return observation is self._policy
+        return observation in self._policy
 
     def _get_utility(self, observation: D.T_agent[D.T_observation]) -> D.T_value:
         if observation not in self.values:
@@ -67,13 +67,17 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         self._weight = weight
         self.max_iter = max_iter
         self.max_depth = max_depth
-        self._plan = []
+        self._plan: List[D.T_event] = []
         self.values = {}
 
         self._verbose = verbose
 
         self.heuristic_changed = False
-        self._policy = {}
+        self._policy: Dict[D.T_observation, Optional[D.T_event]] = {}
+
+    def get_policy(self) -> Dict[D.T_observation, Optional[D.T_event]]:
+        """Return the computed policy."""
+        return self._policy
 
     def _init_solve(self, domain_factory: Callable[[], Domain]) -> None:
         """Initialize solver before calling `solve_from()`

--- a/skdecide/hub/solver/lrtdp/lrtdp.py
+++ b/skdecide/hub/solver/lrtdp/lrtdp.py
@@ -179,6 +179,7 @@ try:
             D.T_agent[D.T_observation],
             Tuple[D.T_agent[D.T_concurrency[D.T_event]], float],
         ]:
+            """Return the computed policy."""
             return self._solver.get_policy()
 
 except ImportError:

--- a/skdecide/hub/solver/martdp/martdp.py
+++ b/skdecide/hub/solver/martdp/martdp.py
@@ -197,6 +197,7 @@ try:
             D.T_agent[D.T_observation],
             Tuple[D.T_agent[D.T_concurrency[D.T_event]], float],
         ]:
+            """Return the computed policy."""
             return self._solver.get_policy()
 
 except ImportError:

--- a/skdecide/hub/solver/mcts/mcts.py
+++ b/skdecide/hub/solver/mcts/mcts.py
@@ -221,6 +221,7 @@ try:
             D.T_agent[D.T_observation],
             Tuple[D.T_agent[D.T_concurrency[D.T_event]], float],
         ]:
+            """Return the computed policy."""
             return self._solver.get_policy()
 
         def get_action_prefix(self) -> List[D.T_agent[D.T_observation]]:

--- a/skdecide/hub/solver/ray_rllib/ray_rllib.py
+++ b/skdecide/hub/solver/ray_rllib/ray_rllib.py
@@ -14,6 +14,7 @@ from ray.rllib.env.wrappers.multi_agent_env_compatibility import (
     MultiAgentEnvCompatibility,
 )
 from ray.rllib.models import ModelCatalog
+from ray.rllib.policy.policy import Policy
 from ray.rllib.utils.from_config import NotProvided
 from ray.tune.registry import register_env
 
@@ -85,6 +86,13 @@ class RayRLlib(Solver, Policies, Restorable):
             )
 
         ray.init(ignore_reinit_error=True)
+
+    def get_policy(self) -> Dict[str, Policy]:
+        """Return the computed policy."""
+        return {
+            policy_id: self._algo.get_policy(policy_id=policy_id)
+            for policy_id in self._policy_configs
+        }
 
     @classmethod
     def _check_domain_additional(cls, domain: Domain) -> bool:

--- a/skdecide/hub/solver/riw/riw.py
+++ b/skdecide/hub/solver/riw/riw.py
@@ -182,6 +182,7 @@ try:
             D.T_agent[D.T_observation],
             Tuple[D.T_agent[D.T_concurrency[D.T_event]], float],
         ]:
+            """Return the computed policy."""
             return self._solver.get_policy()
 
         def get_action_prefix(self) -> List[D.T_agent[D.T_observation]]:

--- a/skdecide/hub/solver/stable_baselines/stable_baselines.py
+++ b/skdecide/hub/solver/stable_baselines/stable_baselines.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional, Type, Union
 
+from stable_baselines3.common.base_class import BaseAlgorithm
+from stable_baselines3.common.policies import BasePolicy
 from stable_baselines3.common.vec_env import DummyVecEnv
 
 from skdecide import Domain, Solver
@@ -35,9 +37,9 @@ class StableBaseline(Solver, Policies, Restorable):
 
     def __init__(
         self,
-        algo_class: type,
-        baselines_policy: Any,
-        learn_config: Dict = None,
+        algo_class: Type[BaseAlgorithm],
+        baselines_policy: Union[str, Type[BasePolicy]],
+        learn_config: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize StableBaselines.
@@ -97,3 +99,7 @@ class StableBaseline(Solver, Policies, Restorable):
         self._unwrap_obs = lambda o: next(
             iter(domain.get_observation_space().to_unwrapped([o]))
         )
+
+    def get_policy(self) -> BasePolicy:
+        """Return the computed policy."""
+        return self._algo.policy

--- a/skdecide/hub/solver/up/up.py
+++ b/skdecide/hub/solver/up/up.py
@@ -92,5 +92,10 @@ class UPSolver(Solver, DeterministicPolicies, Utilities):
     def _get_utility(self, observation: D.T_agent[D.T_observation]) -> D.T_value:
         return self._values[observation]
 
+    def get_policy(self) -> Dict[D.T_agent[D.T_observation], SkUPAction]:
+        """Return the computed policy."""
+        return self._policy
+
     def get_plan(self) -> List[SkUPAction]:
+        """Return the computed plan."""
         return self._plan

--- a/tests/solvers/python/test_python_solvers.py
+++ b/tests/solvers/python/test_python_solvers.py
@@ -161,6 +161,12 @@ def test_solve_python(solver_python):
     with solver_type(**solver_args) as slv:
         GridDomain.solve_with(slv)
         plan, cost = get_plan(dom, slv)
+        # test get_plan and get_policy
+        if hasattr(slv, "get_policy"):
+            slv.get_policy()
+        if hasattr(slv, "get_plan"):
+            slv.get_plan()
+
     assert solver_type.check_domain(dom) and (
         (not solver_python["optimal"]) or (cost == 18 and len(plan) == 18)
     )

--- a/tests/solvers/python/test_ray_rllib.py
+++ b/tests/solvers/python/test_ray_rllib.py
@@ -165,8 +165,11 @@ def test_ray_rllib_solver():
     solver_factory = lambda: RayRLlib(config=config_factory(), **solver_kwargs)
 
     # solve
-    solver = RockPaperScissors.solve_with(solver_factory(), domain_factory)
+    solver: RayRLlib = RockPaperScissors.solve_with(solver_factory(), domain_factory)
     assert hasattr(solver, "_algo")
+
+    # test get_policy()
+    policy = solver.get_policy()
 
     # store
     tmp_save_dir = "TEMP_RLlib"

--- a/tests/solvers/python/test_up_bridge_solver.py
+++ b/tests/solvers/python/test_up_bridge_solver.py
@@ -133,6 +133,7 @@ def test_up_bridge_solver_numeric():
         engine_params={"output_stream": sys.stdout},
     ) as solver:
         UPDomain.solve_with(solver, domain_factory)
+
         s = domain.get_initial_state()
         step = 0
         p = []
@@ -140,6 +141,9 @@ def test_up_bridge_solver_numeric():
             p.append(solver.get_next_action(s))
             s = domain.get_next_state(s, p[-1])
             step += 1
+
+        # test get_policy()
+        policy = solver.get_policy()
 
     assert (
         UPSolver.check_domain(domain)


### PR DESCRIPTION
Add `get_policy()` or `get_plan()` to solvers whenever it makes sense. As the output type may vary according to solver, we do not add it in the generic API of a solver.

We fix along the way a bug in `LRTAstar._is_policy_defined_for`  (`is` -> `in`).