### PR TITLE
Use macos-12 instead of macos-latest to build wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           from os import environ
 
           python_version = ["3.8", "3.9", "3.10", "3.11"]
-          build = [ "macos-latest", "ubuntu-latest", "windows-latest" ]
+          build = [ "macos-12", "ubuntu-latest", "windows-latest" ]
           test = [ "macos-11", "macos-12", "ubuntu-22.04", "ubuntu-20.04", "windows-2019", "windows-2022"]
           build_doc = "true"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           from os import environ
 
           python_version = ["3.8", "3.9", "3.10", "3.11"]
-          build_dict = { "macos":["macos-11"], "ubuntu":["ubuntu-latest"], "windows":["windows-latest"] }
+          build_dict = { "macos":["macos-12"], "ubuntu":["ubuntu-latest"], "windows":["windows-latest"] }
           test_dict = { "macos":["macos-12", "macos-11"], "ubuntu":["ubuntu-22.04", "ubuntu-20.04"], "windows":["windows-2019", "windows-2022" ]}
           deploy_test_pypi = "true"
           python_version_per_os = {os: python_version for os in build_dict}


### PR DESCRIPTION
Now macos-latest = macos-14 on arm64, with python>=3.10 available only, and not conda available.