### PR TITLE
Update local build instructions in the docs

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -46,6 +46,16 @@ brew install cmake
 brew install boost
 brew install libomp
 ```
+You must also set some environment variables to instruct the build process on how to find boost and openMP.
+For instance, on macOS, it is done via:
+```shell
+export Boost_ROOT=$(brew --cellar boost)/$(brew list --versions boost | tr ' ' '\n' | tail -1)
+export OpenMP_ROOT=$(brew --cellar libomp)/$(brew list --versions libomp | tr ' ' '\n' | tail -1)
+export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
+export CFLAGS="$CFLAGS -I$OpenMP_ROOT/include"
+export CXXFLAGS="$CXXFLAGS -I$OpenMP_ROOT/include"
+export LDFLAGS="$LDFLAGS -Wl,-rpath,$OpenMP_ROOT/lib -L$OpenMP_ROOT/lib -lomp"
+```
 
 #### Installation with pyenv + poetry
 
@@ -69,9 +79,9 @@ Here are the steps to follow:
 
   - Use poetry to install the project:
 
-      - Install [poetry](https://python-poetry.org/docs/master/#installation).
+      - Install [poetry](https://python-poetry.org/docs/#installation).
           ```shell
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+          curl -sSL https://install.python-poetry.org | python3 -
           export PATH="$HOME/.local/bin:$PATH"  # add path to poetry
           ```
 


### PR DESCRIPTION
This PR adds hints in the documentation to locally build scikit-decide with poetry.
More specifically, the documentation now indicates the environment variables that must be set prior to locally building and installing the library with poetry.
Not properly setting those environment variables can result in deactivating some options in scikit-decide, e.g. algorithm parallelism.
Those environment variables are set by the building and deployment github actions but they were not mentioned in the documentation for the people who want to build the library on their own.