### PR TITLE
Implement callbacks for python solvers

### DIFF
--- a/skdecide/hub/solver/cgp/pycgp/cgpes.py
+++ b/skdecide/hub/solver/cgp/pycgp/cgpes.py
@@ -2,13 +2,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations  # allow using CGPWrapper in annotations
+
 import os
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 from joblib import Parallel, delayed
 
 from .cgp import CGP
 from .evaluator import Evaluator
+
+if TYPE_CHECKING:  # avoids circular imports
+    from ..cgp import CGPWrapper
 
 
 class CGPES:
@@ -19,10 +25,14 @@ class CGPES:
         mutation_rate_outputs,
         father,
         evaluator,
+        cgpwrapper: CGPWrapper,
+        callback: Callable[[CGPWrapper], bool],
         folder="genomes",
         num_cpus=1,
         verbose=True,
     ):
+        self.callback = callback
+        self.cgpwrapper = cgpwrapper
         self.num_offsprings = num_offsprings
         self.mutation_rate_nodes = mutation_rate_nodes
         self.mutation_rate_outputs = mutation_rate_outputs
@@ -116,3 +126,6 @@ class CGPES:
                     + str(self.current_fitness)
                     + ".txt"
                 )
+            # Stopping because of user's callback?
+            if self.callback(self.cgpwrapper):
+                break

--- a/skdecide/hub/solver/do_solver/do_solver_scheduling.py
+++ b/skdecide/hub/solver/do_solver/do_solver_scheduling.py
@@ -166,7 +166,7 @@ class DOSolver(Solver, DeterministicPolicies):
         policy_method_params: PolicyMethodParams,
         method: SolvingMethod = SolvingMethod.PILE,
         dict_params: Optional[Dict[Any, Any]] = None,
-        callback: Optional[Callable[[DOSolver], bool]] = None,
+        callback: Callable[[DOSolver], bool] = lambda solver: False,
     ):
         self.callback = callback
         self.method = method
@@ -206,10 +206,7 @@ class DOSolver(Solver, DeterministicPolicies):
                 self.dict_params[k] = params[k]
 
         # callbacks
-        if self.callback is None:
-            callbacks = []
-        else:
-            callbacks = [_DOCallback(callback=self.callback, solver=self)]
+        callbacks = [_DOCallback(callback=self.callback, solver=self)]
         copy_dict_params = deepcopy(self.dict_params)
         if "callbacks" in copy_dict_params:
             callbacks = callbacks + copy_dict_params.pop("callbacks")

--- a/skdecide/hub/solver/lrtastar/lrtastar.py
+++ b/skdecide/hub/solver/lrtastar/lrtastar.py
@@ -36,6 +36,8 @@ class D(
 
 
 class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
+    """Learning Real-Time A* solver."""
+
     T_domain = D
 
     def _get_next_action(
@@ -60,7 +62,20 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         verbose: bool = False,
         max_iter=5000,
         max_depth=200,
+        callback: Callable[[LRTAstar], bool] = lambda solver: False,
     ) -> None:
+        """
+
+        # Parameters
+        heuristic
+        weight
+        verbose
+        max_iter
+        max_depth
+        callback: function called at each solver iteration. If returning true, the solve process stops.
+
+        """
+        self.callback = callback
         self._heuristic = (
             (lambda _, __: Value(cost=0.0)) if heuristic is None else heuristic
         )
@@ -113,7 +128,7 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         iteration = 0
         best_cost = float("inf")
         # best_path = None
-        while True:
+        while not self.callback(self):
             print(memory)
             dead_end, cumulated_cost, current_roll, list_action = self.doTrial(memory)
             if self._verbose:

--- a/skdecide/hub/solver/maxent_irl/maxent_irl.py
+++ b/skdecide/hub/solver/maxent_irl/maxent_irl.py
@@ -22,6 +22,8 @@ class D(RLDomain):
 
 
 class MaxentIRL(Solver, Policies, Restorable):
+    """Maximum Entropy Inverse Reinforcement Learning solver."""
+
     T_domain = D
 
     def __init__(
@@ -34,7 +36,23 @@ class MaxentIRL(Solver, Policies, Restorable):
         theta_learning_rate=0.05,
         n_epochs=20000,
         expert_trajectories="maxent_expert_demo.npy",
+        callback: Callable[[MaxentIRL], bool] = lambda solver: False,
     ) -> None:
+        """
+
+        # Parameters
+        n_states
+        n_actions
+        one_feature
+        gamma
+        q_learning_rate
+        theta_learning_rate
+        n_epochs
+        expert_trajectories
+        callback: function called at each solver epoch. If returning true, the solve process stops.
+
+        """
+        self.callback = callback
         self.n_states = n_states
         self.feature_matrix = np.eye(self.n_states)
         self.n_actions = n_actions
@@ -226,6 +244,10 @@ class MaxentIRL(Solver, Policies, Restorable):
                     "./" + self.expert_trajectories[:-4] + "_maxent_q_table",
                     arr=self.q_table,
                 )
+
+            # Stopping because of user's callback?
+            if self.callback(self):
+                break
 
         self.q_table = np.load(
             file=self.expert_trajectories[:-4] + "_maxent_q_table.npy"

--- a/skdecide/hub/solver/pomcp/pomcp.py
+++ b/skdecide/hub/solver/pomcp/pomcp.py
@@ -36,9 +36,27 @@ class D(
 
 
 class POMCP(Solver, DeterministicPolicies):
+    """Partially-Observable Monte Carlo Planning solver."""
+
     T_domain = D
 
-    def __init__(self, max_iterations=5000, max_depth=50, n_samples=5000) -> None:
+    def __init__(
+        self,
+        max_iterations=5000,
+        max_depth=50,
+        n_samples=5000,
+        callback: Callable[[POMCP], bool] = lambda solver: False,
+    ) -> None:
+        """
+
+        # Parameters
+        max_iterations
+        max_depth
+        n_samples
+        callback: function called at each solver iteration. If returning true, the solve process stops.
+
+        """
+        self.callback = callback
         self._max_iterations = max_iterations
         self._max_depth = max_depth
         self._n_samples = n_samples
@@ -86,7 +104,9 @@ class POMCP(Solver, DeterministicPolicies):
 
         # Now, we can make a decision from the new belief state:
         iterations = 0
-        while iterations < self._max_iterations:  # or some other cut-off
+        while iterations < self._max_iterations and not self.callback(
+            self
+        ):  # or some other cut-off
             # sample a state from the current belief
             state = random.choice(self._belief)
             self._tree_search(state, self._act_history, self._obs_history, 0)


### PR DESCRIPTION
We add a callback hook for:
- ARS
- CGP
- lazy A*
- LRT A*
- MaxentIRL
- POMCP

A callback is a function, called at each solver's iteration,  taking the solver as argument and returning a boolean. If returning True, the solver stops.

We also make some intermediate results attributes from the solver to be accessible in the callback.

And add limited docstring so that the signature of solvers `__init__()` will show in the doc with the callback behaviour documented.