### PR TITLE
Replace `Domain.solve_with()` by direct usage of `solver.solve()` and `solver.load()`

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -82,7 +82,7 @@ mysolver = LazyAstar(domain_factory=MyDomain)
 Here is how to solve `MyDomain` with `mysolver`:
 
 ```python
-MyDomain.solve_with(mysolver)
+mysolver.solve()
 ```
 
 ### Test the solution
@@ -120,7 +120,7 @@ mysolver._cleanup()
 Note that this is automatically done if you use the solver within a `with` statement:
 ```python
 with LazyAstar(domain_factory=MyDomain) as mysolver:
-    MyDomain.solve_with(mysolver)
+    mysolver.solve()
     utils.rollout(MyDomain(), mysolver)
 ```
 :::

--- a/examples/ars_solver.py
+++ b/examples/ars_solver.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
             domain_factory=lambda: domain_type(**selected_domain["config"]),
         )
         with solver_factory() as solver:
-            GymDomain.solve_with(solver)
+            solver.solve()
             # Test solver solution on domain
             print("==================== TEST SOLVER ====================")
             print(

--- a/examples/baselines_solver.py
+++ b/examples/baselines_solver.py
@@ -37,7 +37,7 @@ if StableBaseline.check_domain(domain):
         verbose=1,
     )
     with solver_factory() as solver:
-        GymDomain.solve_with(solver)
+        solver.solve()
         solver.save("TEMP_Baselines")
         rollout(
             domain,
@@ -55,7 +55,7 @@ Restore saved solution and re-run rollout.
 
 # %%
 with solver_factory() as solver:
-    GymDomain.solve_with(solver, load_path="TEMP_Baselines")
+    solver.load("TEMP_Baselines")
     rollout(
         domain,
         solver,

--- a/examples/cgp_solver.py
+++ b/examples/cgp_solver.py
@@ -32,7 +32,7 @@ if CGP.check_domain(domain):
         domain_factory=domain_factory, folder_name="TEMP_CGP", n_it=25
     )
     with solver_factory() as solver:
-        GymDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain,
             solver,

--- a/examples/full_multisolve.py
+++ b/examples/full_multisolve.py
@@ -409,7 +409,7 @@ if __name__ == "__main__":
                         "domain_factory"
                     ] = lambda: actual_domain_type(**actual_domain_config)
                     with solver_type(**selected_solver["config"]) as solver:
-                        actual_domain_type.solve_with(solver)
+                        solver.solve()
                         rollout(actual_domain, solver, **selected_domain["rollout"])
                 if hasattr(domain, "close"):
                     domain.close()

--- a/examples/grid_mdp_multisolve.py
+++ b/examples/grid_mdp_multisolve.py
@@ -508,7 +508,7 @@ if __name__ == "__main__":
                 assert solver_type.check_domain(domain)
                 # Solve with selected solver
                 with solver_type(**selected_solver["config"]) as solver:
-                    MyDomain.solve_with(solver)  # ,lambda:MyDomain(5,5))
+                    solver.solve()
                     rollout(
                         domain,
                         solver,

--- a/examples/grid_multisolve.py
+++ b/examples/grid_multisolve.py
@@ -480,7 +480,7 @@ if __name__ == "__main__":
                 assert solver_type.check_domain(domain)
                 # Solve with selected solver
                 with solver_type(**selected_solver["config"]) as solver:
-                    MyDomain.solve_with(solver)  # ,lambda:MyDomain(5,5))
+                    solver.solve()
                     rollout(
                         domain,
                         solver,

--- a/examples/gym_jsbsim_greedy.py
+++ b/examples/gym_jsbsim_greedy.py
@@ -164,7 +164,7 @@ domain.reset()
 
 if GreedyPlanner.check_domain(domain):
     with GreedyPlanner(domain_factory=domain_factory) as solver:
-        GymGreedyDomain.solve_with(solver)
+        solver.solve()
         initial_state = solver._domain.reset()
         rollout(
             domain,

--- a/examples/gym_jsbsim_iw.py
+++ b/examples/gym_jsbsim_iw.py
@@ -310,7 +310,7 @@ if IW.check_domain(domain_factory()):
         verbose=False,
     )
     with solver_factory() as solver:
-        GymIWDomain.solve_with(solver)
+        solver.solve()
         evaluation_domain = EvaluationDomain(solver._domain)
         evaluation_domain.reset()
         rollout(

--- a/examples/gym_jsbsim_riw.py
+++ b/examples/gym_jsbsim_riw.py
@@ -352,7 +352,7 @@ if RIW.check_domain(domain):
         verbose=False,
     )
     with solver_factory() as solver:
-        GymRIWDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain,
             solver,

--- a/examples/gym_jsbsim_uct.py
+++ b/examples/gym_jsbsim_uct.py
@@ -397,7 +397,7 @@ if UCT.check_domain(domain_factory()):
         verbose=False,
     )
     with solver_factory() as solver:
-        GymUCTRawDomain.solve_with(solver)
+        solver.solve()
         solver._domain.reset()
         rollout(
             domain_factory(),

--- a/examples/gym_line_control.py
+++ b/examples/gym_line_control.py
@@ -277,7 +277,7 @@ if RIW.check_domain(domain):
         verbose=False,
     )
     with solver_factory() as solver:
-        GymRIWDomain.solve_with(solver)
+        solver.solve()
         initial_state = solver._domain.reset()
         rollout(
             domain,

--- a/examples/maxent_irl_solver.py
+++ b/examples/maxent_irl_solver.py
@@ -21,7 +21,7 @@ if MaxentIRL.check_domain(domain):
         n_epochs=10000,
     )
     with solver_factory() as solver:
-        GymDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain,
             solver,

--- a/examples/maze_multiagent_mdp_multisolve.py
+++ b/examples/maze_multiagent_mdp_multisolve.py
@@ -554,8 +554,6 @@ if __name__ == "__main__":
             "config": {
                 "multiagent_solver_class": MARTDP,
                 "singleagent_solver_class": LRTDP,
-                "multiagent_domain_class": MultiAgentMaze,
-                "singleagent_domain_class": SingleAgentMaze,
                 "multiagent_domain_factory": lambda: MultiAgentMaze(),
                 "singleagent_domain_factory": lambda multiagent_domain, agent: SingleAgentMaze(
                     multiagent_domain._maze, multiagent_domain._agents_goals[agent]
@@ -595,8 +593,6 @@ if __name__ == "__main__":
             "config": {
                 "multiagent_solver_class": HMCTS,
                 "singleagent_solver_class": LRTDP,
-                "multiagent_domain_class": MultiAgentMaze,
-                "singleagent_domain_class": SingleAgentMaze,
                 "multiagent_domain_factory": lambda: MultiAgentMaze(),
                 "singleagent_domain_factory": lambda multiagent_domain, agent: SingleAgentMaze(
                     multiagent_domain._maze, multiagent_domain._agents_goals[agent]
@@ -676,7 +672,7 @@ if __name__ == "__main__":
                 assert solver_type.check_domain(domain)
                 # Solve with selected solver
                 with solver_type(**selected_solver["config"]) as solver:
-                    MultiAgentMaze.solve_with(solver)
+                    solver.solve()
                     rollout(
                         domain,
                         solver,

--- a/examples/nocycle_grid_goal_mdp.py
+++ b/examples/nocycle_grid_goal_mdp.py
@@ -308,7 +308,7 @@ if __name__ == "__main__":
             assert solver_type.check_domain(domain)
             # Solve with selected solver
             with solver_type(**selected_solver["config"]) as solver:
-                MyDomain.solve_with(solver)
+                solver.solve()
                 # Test solver solution on domain
                 print("==================== TEST SOLVER ====================")
                 rollout(

--- a/examples/rllib_solver_applicable_actions.py
+++ b/examples/rllib_solver_applicable_actions.py
@@ -116,7 +116,7 @@ if RayRLlib.check_domain(domain):
 
     # Start solving
     with solver_factory() as solver:
-        GridWorldFilteredActions.solve_with(solver)
+        solver.solve()
 
         # Test solution
         rollout(

--- a/examples/rllib_solver_gym_domain.py
+++ b/examples/rllib_solver_gym_domain.py
@@ -24,7 +24,7 @@ if RayRLlib.check_domain(domain):
 
     # Start solving
     with solver_factory() as solver:
-        GymDomain.solve_with(solver)
+        solver.solve()
         solver.save("TEMP_RLlib")  # Save results
 
         # Continue solving (just to demonstrate the capability to learn further)
@@ -43,7 +43,7 @@ if RayRLlib.check_domain(domain):
 
     # Restore (latest results) from scratch and re-run
     with solver_factory() as solver:
-        GymDomain.solve_with(solver, load_path="TEMP_RLlib")
+        solver.load("TEMP_RLlib")
         rollout(
             domain,
             solver,

--- a/examples/rllib_solver_skdecide_domain.py
+++ b/examples/rllib_solver_skdecide_domain.py
@@ -21,7 +21,7 @@ if RayRLlib.check_domain(domain):
 
     # Start solving
     with solver_factory() as solver:
-        SimpleGridWorld.solve_with(solver)
+        solver.solve()
 
         # Test solution
         rollout(

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -165,5 +165,5 @@ assert LazyAstar.check_domain(domain)
 with LazyAstar(
     domain_factory=lambda: MyDomain(State(1, 1), State(19, 19), maze_str)
 ) as solver:
-    MyDomain.solve_with(solver)
+    solver.solve()
     rollout(domain, solver, max_steps=100, max_framerate=10, verbose=False)

--- a/examples/up_native_solvers.py
+++ b/examples/up_native_solvers.py
@@ -76,7 +76,7 @@ if UPSolver.check_domain(domain):
         name="pyperplan",
         engine_params={"output_stream": sys.stdout},
     ) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain,
             solver,
@@ -141,7 +141,7 @@ if UPSolver.check_domain(domain):
         name="enhsp-opt",
         engine_params={"output_stream": sys.stdout},
     ) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain,
             solver,

--- a/examples/up_skdecide_solvers.py
+++ b/examples/up_skdecide_solvers.py
@@ -76,7 +76,7 @@ if RayRLlib.check_domain(domain):
         algo_class=DQN,
         train_iterations=1,
     ) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain_factory(),
             solver,
@@ -136,7 +136,7 @@ domain = domain_factory()
 
 if LazyAstar.check_domain(domain):
     with LazyAstar(domain_factory=domain_factory) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain,
             solver,

--- a/notebooks/11_maze_tuto.ipynb
+++ b/notebooks/11_maze_tuto.ipynb
@@ -494,7 +494,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MazeDomain.solve_with(solver)"
+    "solver.solve()"
    ]
   },
   {
@@ -634,7 +634,7 @@
     "\n",
     "```python\n",
     "with solver_factory() as solver:\n",
-    "    MyDomain.solve_with(solver, domain_factory)\n",
+    "    solver.solve()\n",
     "    rollout(domain=domain, solver=solver)\n",
     "```"
    ]
@@ -689,7 +689,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MazeDomain.solve_with(solver)"
+    "solver.solve()"
    ]
   },
   {

--- a/notebooks/12_gym_tuto.ipynb
+++ b/notebooks/12_gym_tuto.ipynb
@@ -334,7 +334,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "GymDomain.solve_with(solver)"
+    "solver.solve()"
    ]
   },
   {
@@ -493,7 +493,7 @@
     "\n",
     "```python\n",
     "with solver_factory() as solver:\n",
-    "    MyDomain.solve_with(solver, domain_factory)\n",
+    "    solver.solve()\n",
     "    rollout(domain=domain, solver=solver)\n",
     "```"
    ]
@@ -565,7 +565,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "GymDomain.solve_with(solver)"
+    "solver.solve()"
    ]
   },
   {
@@ -797,7 +797,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "GymDomainForWidthSolvers.solve_with(solver)"
+    "solver.solve()"
    ]
   },
   {

--- a/notebooks/14_benchmarking_tuto.ipynb
+++ b/notebooks/14_benchmarking_tuto.ipynb
@@ -225,9 +225,9 @@
     "    if \"domain_factory\" in signature(Solver.__init__).parameters:\n",
     "        solver_args[\"domain_factory\"] = MyDomain\n",
     "    # Solve\n",
-    "    with Solver(**solver_args) as s:\n",
-    "        solution = MyDomain.solve_with(s)\n",
-    "        score = mean_episode_reward(solution)\n",
+    "    with Solver(**solver_args) as solver:\n",
+    "        solver.solve()\n",
+    "        score = mean_episode_reward(solver)\n",
     "    # Feed the score back to Tune\n",
     "    train.report({\"mean_episode_reward\": score})"
    ]

--- a/notebooks/15_flightplanning_tuto.ipynb
+++ b/notebooks/15_flightplanning_tuto.ipynb
@@ -216,8 +216,7 @@
     "with Astar(\n",
     "    heuristic=lambda d, s: d.heuristic(s), domain_factory=domain_factory, parallel=False\n",
     ") as solver:\n",
-    "    domain.solve_with(solver=solver)\n",
-    "\n",
+    "    solver.solve()\n",
     "    domain.custom_rollout(solver=solver)"
    ]
   },
@@ -255,8 +254,7 @@
     "with Astar(\n",
     "    heuristic=lambda d, s: d.heuristic(s), domain_factory=domain_factory, parallel=False\n",
     ") as solver:\n",
-    "    domain.solve_with(solver=solver)\n",
-    "\n",
+    "    solver.solve()\n",
     "    domain.custom_rollout(solver=solver)"
    ]
   },
@@ -298,8 +296,7 @@
     "with Astar(\n",
     "    heuristic=lambda d, s: d.heuristic(s), domain_factory=domain_factory, parallel=False\n",
     ") as solver:\n",
-    "    domain.solve_with(solver=solver)\n",
-    "\n",
+    "    solver.solve()\n",
     "    domain.custom_rollout(solver=solver)"
    ]
   },
@@ -330,8 +327,7 @@
     "with Astar(\n",
     "    heuristic=lambda d, s: d.heuristic(s), domain_factory=domain_factory, parallel=False\n",
     ") as solver:\n",
-    "    domain.solve_with(solver=solver)\n",
-    "\n",
+    "    solver.solve()\n",
     "    domain.custom_rollout(solver=solver)"
    ]
   }

--- a/skdecide/builders/solver/fromanystatesolvability.py
+++ b/skdecide/builders/solver/fromanystatesolvability.py
@@ -23,11 +23,15 @@ class FromInitialState:
     ) -> None:
         """Run the solving process.
 
+        After solving by calling self._solve(), autocast itself so that rollout methods apply
+        to the domain original characteristics.
+
         !!! tip
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
         """
-        return self._solve()
+        self._solve()
+        self.autocast()
 
     def _solve(
         self,
@@ -51,6 +55,9 @@ class FromAnyState(FromInitialState):
     ) -> None:
         """Run the solving process.
 
+        After solving by calling self._solve(), autocast itself so that rollout methods apply
+        to the domain original characteristics.
+
         # Parameters
         from_memory: The source memory (state or history) from which we begin the solving process.
             If None, initial state is used if the domain is initializable, else a ValueError is raised.
@@ -59,7 +66,8 @@ class FromAnyState(FromInitialState):
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
         """
-        return self._solve(from_memory=from_memory)
+        self._solve(from_memory=from_memory)
+        self.autocast()
 
     def _solve(
         self,
@@ -94,6 +102,9 @@ class FromAnyState(FromInitialState):
         !!! tip
             Create the domain first by calling the @FromAnyState.init_solve() method
 
+        After solving by calling self._solve_from(), autocast itself so that rollout methods apply
+        to the domain original characteristics.
+
         # Parameters
         memory: The source memory (state or history) of the transition.
 
@@ -101,7 +112,8 @@ class FromAnyState(FromInitialState):
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
         """
-        return self._solve_from(memory)
+        self._solve_from(memory)
+        self.autocast()
 
     def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:
         """Run the solving process from a given state.

--- a/skdecide/builders/solver/restorability.py
+++ b/skdecide/builders/solver/restorability.py
@@ -15,7 +15,6 @@ class Restorable:
     """A solver must inherit this class if its state can be saved and reloaded (to continue computation later on or
     reuse its solution)."""
 
-    @autocastable
     def save(self, path: str) -> None:
         """Save the solver state to given path.
 
@@ -32,14 +31,17 @@ class Restorable:
         """
         raise NotImplementedError
 
-    @autocastable
     def load(self, path: str) -> None:
         """Restore the solver state from given path.
+
+        After calling self._load(), autocast itself so that rollout methods apply
+        to the domain original characteristics.
 
         # Parameters
         path: The path where the solver state was saved.
         """
-        return self._load(path)
+        self._load(path)
+        self.autocast()
 
     def _load(self, path: str) -> None:
         """Restore the solver state from given path.

--- a/skdecide/domains.py
+++ b/skdecide/domains.py
@@ -112,45 +112,6 @@ class Domain(
     T_predicate = T_predicate
     T_info = T_info
 
-    @classmethod
-    def solve_with(
-        cls,
-        solver: Solver,
-        load_path: Optional[str] = None,
-        from_memory: Optional[D.T_memory[T_state]] = None,
-    ) -> Solver:
-        """Solve the domain with a new or loaded solver and return it auto-cast to the level of the domain.
-
-        By default, #Solver.check_domain() provides some boilerplate code and internally
-        calls #Solver._check_domain_additional() (which returns True by default but can be overridden  to define
-        specific checks in addition to the "domain requirements"). The boilerplate code automatically checks whether all
-        domain requirements are met.
-
-        # Parameters
-        solver: The solver.
-        load_path: The path to restore the solver state from (if None, the solving process will be launched instead).
-        from_memory: The source memory (state or history) from which we begin the solving process.
-            To be used, if the solving process must begin from a specific state,
-            and only for solvers having the characteristic #FromAnyState, else raise a ValueError.
-            Ignored if load_path is used.
-
-        # Returns
-        The new solver (auto-cast to the level of the domain).
-        """
-        if load_path is not None:
-            solver.load(load_path)
-        else:
-            if isinstance(solver, FromAnyState):
-                solver.solve(from_memory=from_memory)
-            elif from_memory is None:
-                solver.solve()
-            else:
-                raise ValueError(
-                    f"`from_memory` must be None when used with a solver not having {FromAnyState.__name__} characteristic."
-                )
-        autocast_all(solver, solver.T_domain, cls)
-        return solver
-
 
 # ALTERNATE BASE CLASSES (for typical combinations)
 

--- a/skdecide/hub/domain/flight_planning/domain.py
+++ b/skdecide/hub/domain/flight_planning/domain.py
@@ -1657,7 +1657,7 @@ def fuel_optimisation(
 def simple_fuel_loop(solver_factory, domain_factory, max_steps: int = 100) -> float:
     domain = domain_factory()
     with solver_factory() as solver:
-        domain.solve_with(solver)
+        solver.solve()
         observation: State = domain.reset()
         solver.reset()
 

--- a/skdecide/hub/solver/pomcp/pomcp.py
+++ b/skdecide/hub/solver/pomcp/pomcp.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
     domain = domain_factory()
     if POMCP.check_domain(domain):
         with POMCP(domain_factory=domain_factory) as solver:
-            MasterMind.solve_with(solver)
+            solver.solve()
             rollout(
                 domain,
                 solver,

--- a/skdecide/solvers.py
+++ b/skdecide/solvers.py
@@ -5,7 +5,7 @@
 """This module contains base classes for quickly building solvers."""
 from __future__ import annotations
 
-from typing import Callable, List
+from typing import Callable, List, Optional, Type
 
 from skdecide import autocast_all
 from skdecide.builders.solver.fromanystatesolvability import FromInitialState
@@ -38,6 +38,8 @@ class Solver(FromInitialState):
     """
 
     T_domain = Domain
+
+    _already_autocast = False
 
     def __init__(
         self,
@@ -177,6 +179,20 @@ class Solver(FromInitialState):
         is a good habit to always call solvers within a 'with' statement.
         """
         self._cleanup()
+
+    def autocast(self, domain_cls: Optional[Type[Domain]] = None) -> None:
+        """Autocast itself to the level corresponding to the given domain class.
+
+        # Parameters
+        domain_cls: the domain class to which level the solver needs to autocast itself.
+            By default, use the original domain factory passed to its constructor.
+
+        """
+        if not self._already_autocast:
+            if domain_cls is None:
+                domain_cls = type(self._original_domain_factory())
+            autocast_all(self, self.T_domain, domain_cls)
+            self._already_autocast = True
 
 
 # ALTERNATE BASE CLASSES (for typical combinations)

--- a/tests/domains/python/test_up_bridge_domain.py
+++ b/tests/domains/python/test_up_bridge_domain.py
@@ -112,7 +112,7 @@ def test_up_bridge_domain_planning():
     with LazyAstar(
         domain_factory=domain_factory,
     ) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
         s = domain.get_initial_state()
         step = 0
         p = []
@@ -207,7 +207,7 @@ def test_up_bridge_domain_rl():
         algo_class=DQN,
         train_iterations=1,
     ) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
         rollout(
             domain_factory(),
             solver,

--- a/tests/domains/test_gym.py
+++ b/tests/domains/test_gym.py
@@ -79,7 +79,7 @@ def test_gymdomain():
     solver = CGP(
         domain_factory=domain_factory, folder_name="TEMP_CGP", n_it=2, verbose=False
     )
-    GymDomain.solve_with(solver)
+    solver.solve()
     domain = domain_factory()
     observation = domain.reset()
     domain.render()

--- a/tests/flight_planning/test_flight_planning.py
+++ b/tests/flight_planning/test_flight_planning.py
@@ -33,7 +33,7 @@ def test_flight_planning():
     solver = LazyAstar(
         domain_factory=domain_factory, heuristic=lambda d, s: d.heuristic(s)
     )
-    domain.solve_with(solver=solver)
+    solver.solve()
 
     assert solver.check_domain(domain)
 
@@ -68,6 +68,6 @@ def test_flight_planning_fuel_loop():
     solver = LazyAstar(
         domain_factory=domain_factory, heuristic=lambda d, s: d.heuristic(s)
     )
-    domain.solve_with(solver=solver)
+    solver.solve()
 
     assert solver.check_domain(domain)

--- a/tests/solvers/cpp/parallelism/test_parallel_deterministic_algorithms.py
+++ b/tests/solvers/cpp/parallelism/test_parallel_deterministic_algorithms.py
@@ -478,7 +478,7 @@ if __name__ == "__main__":
             for i in range(50):
                 s["config"]["shared_memory_proxy"] = None
                 with solver_type(**s["config"]) as solver:
-                    MyDomain.solve_with(solver)  # ,lambda:MyDomain(5,5))
+                    solver.solve()
                     rollout(
                         domain,
                         solver,
@@ -489,7 +489,7 @@ if __name__ == "__main__":
             for i in range(50):
                 s["config"]["shared_memory_proxy"] = GridShmProxy()
                 with solver_type(**s["config"]) as solver:
-                    MyDomain.solve_with(solver)  # ,lambda:MyDomain(5,5))
+                    solver.solve()
                     rollout(
                         domain,
                         solver,

--- a/tests/solvers/cpp/parallelism/test_parallel_probabilistic_algorithms.py
+++ b/tests/solvers/cpp/parallelism/test_parallel_probabilistic_algorithms.py
@@ -478,7 +478,7 @@ if __name__ == "__main__":
             for i in range(50):
                 s["config"]["shared_memory_proxy"] = None
                 with solver_type(**s["config"]) as solver:
-                    MyDomain.solve_with(solver)  # ,lambda:MyDomain(5,5))
+                    solver.solve()
                     rollout(
                         domain,
                         solver,
@@ -489,7 +489,7 @@ if __name__ == "__main__":
             for i in range(50):
                 s["config"]["shared_memory_proxy"] = GridShmProxy()
                 with solver_type(**s["config"]) as solver:
-                    MyDomain.solve_with(solver)  # ,lambda:MyDomain(5,5))
+                    solver.solve()
                     rollout(
                         domain,
                         solver,

--- a/tests/solvers/cpp/test_cpp_solvers.py
+++ b/tests/solvers/cpp/test_cpp_solvers.py
@@ -485,7 +485,7 @@ def test_solver_cpp(solver_cpp, parallel, shared_memory):
     solver_args["domain_factory"] = lambda: GridDomain()
 
     with solver_type(**solver_args) as slv:
-        GridDomain.solve_with(slv)
+        slv.solve()
         plan, cost = get_plan(dom, slv)
 
     assert solver_type.check_domain(dom) and (
@@ -538,7 +538,7 @@ def test_solver_cpp_with_cb(solver_cpp, parallel, shared_memory, caplog):
 
     with solver_type(**solver_args) as slv:
         with caplog.at_level(logging.WARNING):
-            GridDomain.solve_with(slv)
+            slv.solve()
 
     # Check that 2 iterations were done and messages logged by callback
     assert "End of iteration #1" in caplog.text

--- a/tests/solvers/python/test_python_solvers.py
+++ b/tests/solvers/python/test_python_solvers.py
@@ -163,7 +163,7 @@ def test_solve_python(solver_python):
         solver_args["algo_class"] = DQN
 
     with solver_type(**solver_args) as slv:
-        GridDomain.solve_with(slv)
+        slv.solve()
         plan, cost = get_plan(dom, slv)
         # test get_plan and get_policy
         if hasattr(slv, "get_policy"):
@@ -214,7 +214,7 @@ def test_solve_python_with_cb(solver_python, caplog):
     solver_args["callback"] = MyCallback(solver_cls=solver_type)
 
     with solver_type(**solver_args) as slv:
-        GridDomain.solve_with(slv)
+        slv.solve()
 
     # Check that 2 iterations only were done and messages logged by callback
     assert "End of iteration #2" in caplog.text

--- a/tests/solvers/python/test_ray_rllib.py
+++ b/tests/solvers/python/test_ray_rllib.py
@@ -161,8 +161,12 @@ def test_ray_rllib_solver():
     )
 
     # solve
-    solver: RayRLlib = RockPaperScissors.solve_with(solver_factory())
+    solver = solver_factory()
+    solver.solve()
     assert hasattr(solver, "_algo")
+
+    # solve further
+    solver.solve()
 
     # test get_policy()
     policy = solver.get_policy()
@@ -204,9 +208,8 @@ def test_ray_rllib_solver_with_filtered_actions():
     config = DQN.get_default_config().resources(
         num_cpus_per_worker=0.5
     )  # set num of CPU<1 to avoid hanging for ever in github actions on macos 11
-    solver = GridWorldFilteredActions.solve_with(
-        RayRLlib(domain_factory=domain_factory, config=config, **solver_kwargs),
-    )
+    solver = RayRLlib(domain_factory=domain_factory, config=config, **solver_kwargs)
+    solver.solve()
     assert hasattr(solver, "_algo")
 
     # rollout
@@ -227,9 +230,8 @@ def test_ray_rllib_solver_on_single_agent_domain():
     config = PPO.get_default_config().resources(
         num_cpus_per_worker=0.5
     )  # set num of CPU<1 to avoid hanging for ever in github actions on macos 11
-    solver = GymDomain.solve_with(
-        RayRLlib(domain_factory=domain_factory, config=config, **solver_kwargs)
-    )
+    solver = RayRLlib(domain_factory=domain_factory, config=config, **solver_kwargs)
+    solver.solve()
     assert hasattr(solver, "_algo")
 
     # rollout

--- a/tests/solvers/python/test_up_bridge_solver.py
+++ b/tests/solvers/python/test_up_bridge_solver.py
@@ -59,7 +59,7 @@ def test_up_bridge_solver_classic():
         name="pyperplan",
         engine_params={"output_stream": sys.stdout},
     ) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
         s = domain.get_initial_state()
         step = 0
         p = []
@@ -134,7 +134,7 @@ def test_up_bridge_solver_numeric():
         name="fast-downward-opt",
         engine_params={"output_stream": sys.stdout},
     ) as solver:
-        UPDomain.solve_with(solver)
+        solver.solve()
 
         s = domain.get_initial_state()
         step = 0


### PR DESCRIPTION
Now that domain_factory is needed anymore in solve_with(), the sole added value to this method is the autocast performed at the end of it.

As it already changed (autocast) the original solve itself, it is equivalent to do so directly at the end of solver.solve() or solver.load()

So   
- we add a `solver.autocast()` method to do so, that can take a domain class as argument or use the original domain factory passed to the solver's constructor
- we call `self.autocast()` at the end of `self.solve()` and `self.load()`
- we replace call to `Domain.solve_with(solver)` by simpler call to `solver.solve()` or `solver.load()` (which seems clearer if the user only wants to load a previously runned solver)
