### PR TITLE
Unify the rollout utilities

### DIFF
--- a/examples/scheduling/computation_time_experiments.py
+++ b/examples/scheduling/computation_time_experiments.py
@@ -1,8 +1,9 @@
+import logging
 import time
 
 from rcpsp_datasets import get_complete_path
 
-from skdecide import rollout_episode
+from skdecide import rollout
 from skdecide.hub.domain.rcpsp.rcpsp_sk import RCPSP
 from skdecide.hub.domain.rcpsp.rcpsp_sk_parser import load_domain
 from skdecide.hub.solver.do_solver.do_solver_scheduling import DOSolver, SolvingMethod
@@ -15,7 +16,7 @@ from skdecide.hub.solver.do_solver.sgs_policies import (
 def do_rollout_comparaison(domain: RCPSP, solver, inplace: bool = True):
     domain.set_inplace_environment(inplace)
     tic = time.perf_counter()
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         solver=solver,
         from_memory=domain.get_initial_state(),
@@ -23,7 +24,9 @@ def do_rollout_comparaison(domain: RCPSP, solver, inplace: bool = True):
         outcome_formatter=None,
         action_formatter=None,
         verbose=False,
-    )
+        goal_logging_level=logging.DEBUG,
+        return_episodes=True,
+    )[0]
     toc = time.perf_counter()
     print(
         f"{toc - tic:0.4f} seconds to rollout policy with inplace={inplace} environment, "

--- a/examples/scheduling/gphh_example.py
+++ b/examples/scheduling/gphh_example.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import operator
 import os
 import pickle
@@ -6,7 +7,7 @@ import pickle
 import numpy as np
 
 from examples.scheduling.rcpsp_datasets import get_complete_path, get_data_available
-from skdecide import rollout_episode
+from skdecide import rollout
 from skdecide.hub.domain.rcpsp.rcpsp_sk import RCPSP
 from skdecide.hub.domain.rcpsp.rcpsp_sk_parser import load_domain
 from skdecide.hub.solver.do_solver.do_solver_scheduling import DOSolver, SolvingMethod
@@ -138,14 +139,17 @@ def fitness_makespan_correlation():
 
         domain.set_inplace_environment(False)
         state = domain.get_initial_state()
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             max_steps=1000,
             solver=gphh_policy,
             from_memory=state,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
 
         policy_makespan = states[-1].t
 
@@ -218,14 +222,17 @@ def run_gphh():
         pickle.dump(dict(hof=heuristic), file)
         file.close()
         solver.set_domain(domain)
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             max_steps=1000,
             solver=solver,
             from_memory=state,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
         print("Cost :", sum([v.cost for v in values]))
         makespans.append(sum([v.cost for v in values]))
 
@@ -301,14 +308,17 @@ def run_pooled_gphh():
             pool_aggregation_method=PoolAggregationMethod.MEAN,
             remove_extremes_values=remove_extreme_values,
         )
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             max_steps=1000,
             solver=pooled_gphh_solver,
             from_memory=state,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
         print("Cost :", sum([v.cost for v in values]))
         makespans.append(sum([v.cost for v in values]))
 
@@ -376,14 +386,17 @@ def run_gphh_with_settings():
         params_gphh=params_gphh,
     )
     solver.solve()
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
         from_memory=state,
         verbose=False,
+        goal_logging_level=logging.DEBUG,
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        action_formatter=None,
+        return_episodes=True,
+    )[0]
     print("Cost :", sum([v.cost for v in values]))
 
 
@@ -448,14 +461,17 @@ def compare_settings():
                 domain.set_inplace_environment(False)
                 state = domain.get_initial_state()
                 solver.set_domain(domain)
-                states, actions, values = rollout_episode(
+                states, actions, values = rollout(
                     domain=domain,
                     max_steps=1000,
                     solver=solver,
                     from_memory=state,
                     verbose=False,
+                    goal_logging_level=logging.DEBUG,
                     outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-                )
+                    action_formatter=None,
+                    return_episodes=True,
+                )[0]
                 print("One GPHH done")
                 print("Best evolved heuristic: ", solver.best_heuristic)
                 print("Cost: ", sum([v.cost for v in values]))
@@ -547,14 +563,17 @@ def run_comparaison_stochastic():
         for i in range(repeat_runs):
             state = domain.get_initial_state()
             solver = None
-            states, actions, values = rollout_episode(
+            states, actions, values = rollout(
                 domain=domain,
                 max_steps=1000,
                 solver=solver,
                 from_memory=state,
                 verbose=False,
+                goal_logging_level=logging.DEBUG,
                 outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-            )
+                action_formatter=None,
+                return_episodes=True,
+            )[0]
             print("One random Walk complete")
             print("Cost :", sum([v.cost for v in values]))
             all_results[original_domain_name]["random_walk"].append(
@@ -578,14 +597,17 @@ def run_comparaison_stochastic():
         )
         solver.solve()
         print(do_solver)
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             solver=solver,
             from_memory=state,
             max_steps=500,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
         print("Cost: ", sum([v.cost for v in values]))
         print("CP done")
         all_results[original_domain_name]["cp"].append(sum([v.cost for v in values]))
@@ -608,14 +630,17 @@ def run_comparaison_stochastic():
             print(do_solver)
             domain: RCPSP = test_domain
             domain.set_inplace_environment(False)
-            states, actions, values = rollout_episode(
+            states, actions, values = rollout(
                 domain=domain,
                 solver=solver,
                 from_memory=state,
                 max_steps=500,
                 verbose=False,
+                goal_logging_level=logging.DEBUG,
                 outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-            )
+                action_formatter=None,
+                return_episodes=True,
+            )[0]
             print("Cost: ", sum([v.cost for v in values]))
             print("CP_SGS done")
             all_results[original_domain_name]["cp_sgs"].append(
@@ -638,14 +663,17 @@ def run_comparaison_stochastic():
         )
         solver.solve()
         print(do_solver)
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             solver=solver,
             from_memory=state,
             max_steps=500,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
         print("Cost: ", sum([v.cost for v in values]))
         print("PILE done")
         all_results[original_domain_name]["pile"].append(sum([v.cost for v in values]))
@@ -721,14 +749,17 @@ def run_comparaison_stochastic():
             domain.set_inplace_environment(False)
             state = domain.get_initial_state()
             solver.set_domain(domain)
-            states, actions, values = rollout_episode(
+            states, actions, values = rollout(
                 domain=domain,
                 max_steps=1000,
                 solver=solver,
                 from_memory=state,
                 verbose=False,
+                goal_logging_level=logging.DEBUG,
                 outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-            )
+                action_formatter=None,
+                return_episodes=True,
+            )[0]
             print("One GPHH done")
             print("Best evolved heuristic: ", solver.best_heuristic)
             print("Cost: ", sum([v.cost for v in values]))
@@ -798,14 +829,17 @@ def run_comparaison():
         for i in range(n_walks):
             state = domain.get_initial_state()
             solver = None
-            states, actions, values = rollout_episode(
+            states, actions, values = rollout(
                 domain=domain,
                 max_steps=1000,
                 solver=solver,
                 from_memory=state,
                 verbose=False,
+                goal_logging_level=logging.DEBUG,
                 outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-            )
+                action_formatter=None,
+                return_episodes=True,
+            )[0]
             print("One random Walk complete")
             print("Cost :", sum([v.cost for v in values]))
             all_results[test_domain_str]["random_walk"].append(
@@ -830,14 +864,17 @@ def run_comparaison():
         )
         solver.solve()
         print(do_solver)
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             solver=solver,
             from_memory=state,
             max_steps=500,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
         print("Cost: ", sum([v.cost for v in values]))
         print("CP done")
         all_results[test_domain_str]["cp"].append(sum([v.cost for v in values]))
@@ -859,14 +896,17 @@ def run_comparaison():
         )
         solver.solve()
         print(do_solver)
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             solver=solver,
             from_memory=state,
             max_steps=500,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
         print("Cost: ", sum([v.cost for v in values]))
         print("CP_SGS done")
         all_results[test_domain_str]["cp_sgs"].append(sum([v.cost for v in values]))
@@ -888,14 +928,17 @@ def run_comparaison():
         )
         solver.solve()
         print(do_solver)
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             solver=solver,
             from_memory=state,
             max_steps=500,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
         print("Cost: ", sum([v.cost for v in values]))
         print("PILE done")
         all_results[test_domain_str]["pile"].append(sum([v.cost for v in values]))
@@ -976,14 +1019,17 @@ def run_comparaison():
             domain.set_inplace_environment(False)
             state = domain.get_initial_state()
             solver.set_domain(domain)
-            states, actions, values = rollout_episode(
+            states, actions, values = rollout(
                 domain=domain,
                 max_steps=1000,
                 solver=solver,
                 from_memory=state,
                 verbose=False,
+                goal_logging_level=logging.DEBUG,
                 outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-            )
+                action_formatter=None,
+                return_episodes=True,
+            )[0]
             print("One GPHH done")
             print("Best evolved heuristic: ", solver.best_heuristic)
             print("Cost: ", sum([v.cost for v in values]))
@@ -1042,14 +1088,17 @@ def compute_ref_permutations():
         all_permutations[td_name] = full_permutation
 
         state = td.get_initial_state()
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=td,
             max_steps=1000,
             solver=solver,
             from_memory=state,
             verbose=False,
+            goal_logging_level=logging.DEBUG,
             outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-        )
+            action_formatter=None,
+            return_episodes=True,
+        )[0]
 
         makespan = sum([v.cost for v in values])
         all_makespans[td_name] = makespan

--- a/examples/scheduling/rcpsp_examples.py
+++ b/examples/scheduling/rcpsp_examples.py
@@ -1,6 +1,6 @@
 from examples.scheduling.rcpsp_datasets import get_complete_path
 from examples.scheduling.rcpsp_multiskill_datasets import get_data_available_ms
-from skdecide import rollout_episode
+from skdecide import rollout
 from skdecide.hub.domain.rcpsp.rcpsp_sk import MSRCPSP, RCPSP
 from skdecide.hub.domain.rcpsp.rcpsp_sk_parser import (
     load_domain,
@@ -17,13 +17,15 @@ def random_walk():
     domain: RCPSP = load_domain(get_complete_path("j301_1.sm"))
     state = domain.get_initial_state()
     domain.set_inplace_environment(False)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         solver=None,
         from_memory=state,
         max_steps=500,
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        action_formatter=None,
+        return_episodes=True,
+    )[0]
     print(sum([v.cost for v in values]))
     print("rollout done")
     print("end times: ")
@@ -65,13 +67,15 @@ def do_singlemode():
     solver.solve()
     print(do_solver)
 
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         solver=solver,
         from_memory=state,
         max_steps=500,
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        action_formatter=None,
+        return_episodes=True,
+    )[0]
     print(sum([v.cost for v in values]))
     print("rollout done")
     print("end times: ")
@@ -92,14 +96,15 @@ def do_multimode():
         method=SolvingMethod.CP,
     )
     solver.solve()
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         solver=solver,
         from_memory=state,
         max_steps=1000,
         action_formatter=lambda a: f"{a}",
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        return_episodes=True,
+    )[0]
     print("rollout done")
     print("end times: ")
     for task_id in states[-1].tasks_details.keys():
@@ -109,14 +114,15 @@ def do_multimode():
 def random_walk_multiskill():
     domain: MSRCPSP = load_multiskill_domain(get_data_available_ms()[0])
     state = domain.get_initial_state()
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         solver=None,
         from_memory=state,
         max_steps=1000,
         action_formatter=lambda a: f"{a}",
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        return_episodes=True,
+    )[0]
     print("rollout done")
     print("end times: ")
     for task_id in states[-1].tasks_details.keys():
@@ -138,14 +144,15 @@ def do_multiskill():
     )
     solver.get_available_methods(domain)
     solver.solve()
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         solver=solver,
         from_memory=state,
         max_steps=3000,
         action_formatter=lambda a: f"{a}",
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        return_episodes=True,
+    )[0]
     print(sum([v.cost for v in values]))
     print("rollout done")
     print("end times: ")

--- a/examples/scheduling/toy_rcpsp_examples.py
+++ b/examples/scheduling/toy_rcpsp_examples.py
@@ -2,7 +2,7 @@ import random
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 
-from skdecide import DiscreteDistribution, Distribution, rollout_episode
+from skdecide import DiscreteDistribution, Distribution, rollout
 from skdecide.builders.domain.scheduling.modes import (
     ConstantModeConsumption,
     ModeConsumption,
@@ -437,13 +437,15 @@ def run_example():
     # domain.set_inplace_environment(False)
     # solver = lazy_astar.LazyAstar(heuristic=None, verbose=True)
     # solver.solve(domain_factory=lambda: domain, from_memory=state)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
         from_memory=state,
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        action_formatter=None,
+        return_episodes=True,
+    )[0]
     print(states[-1])
 
 
@@ -457,13 +459,15 @@ def run_astar():
     print("Initial state : ", state)
     solver = LazyAstar(domain_factory=lambda: domain, heuristic=None, verbose=True)
     solver.solve(from_memory=state)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
         from_memory=state,
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        action_formatter=None,
+        return_episodes=True,
+    )[0]
     print("Cost :", sum([v.cost for v in values]))
 
     from skdecide.hub.solver.do_solver.sk_to_do_binding import (
@@ -486,10 +490,12 @@ def run_astar():
 
 def run_do():
     from skdecide.hub.solver.do_solver.do_solver_scheduling import (
-        BasePolicyMethod,
         DOSolver,
-        PolicyMethodParams,
         SolvingMethod,
+    )
+    from skdecide.hub.solver.do_solver.sgs_policies import (
+        BasePolicyMethod,
+        PolicyMethodParams,
     )
 
     domain = MyExampleRCPSPDomain()
@@ -507,14 +513,15 @@ def run_do():
         method=SolvingMethod.LNS_CP_CALENDAR,
     )
     solver.solve()
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
         from_memory=state,
         action_formatter=lambda o: str(o),
         outcome_formatter=lambda o: f"{o.observation} - cost: {o.value.cost:.2f}",
-    )
+        return_episodes=True,
+    )[0]
     print("Cost :", sum([v.cost for v in values]))
     from skdecide.hub.solver.do_solver.sk_to_do_binding import (
         from_last_state_to_solution,

--- a/notebooks/13_scheduling_tuto.ipynb
+++ b/notebooks/13_scheduling_tuto.ipynb
@@ -174,7 +174,7 @@
    "source": [
     "from typing import Any, Dict, List, Optional, Set, Union\n",
     "\n",
-    "from skdecide import rollout_episode\n",
+    "from skdecide import rollout\n",
     "from skdecide.builders.domain.scheduling.modes import (\n",
     "    ConstantModeConsumption,\n",
     "    ModeConsumption,\n",
@@ -375,7 +375,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The solver has generated a policy for this scheduling problem. Now we can apply the policy to the domain and chack what is the final state. The policy is usually applied through the `rollout_episode` function but let's do it manually this time."
+    "The solver has generated a policy for this scheduling problem. Now we can apply the policy to the domain and chack what is the final state. The policy is usually applied through the `rollout` function but let's do it manually this time."
    ]
   },
   {
@@ -746,7 +746,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now execute the resulting policy using the `rollout_episode` and check the result. "
+    "We can now execute the resulting policy using the `rollout` and check the result. "
    ]
   },
   {
@@ -755,7 +755,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "states, _, _ = rollout_episode(\n",
+    "episodes = rollout(\n",
     "    domain=domain,\n",
     "    solver=solver,\n",
     "    from_memory=state,\n",
@@ -763,7 +763,10 @@
     "    verbose=False,\n",
     "    outcome_formatter=None,\n",
     "    action_formatter=None,\n",
-    ")"
+    "    num_episodes=1,\n",
+    "    return_episodes=True,\n",
+    ")\n",
+    "states, _, _ = episodes[0]"
    ]
   },
   {

--- a/skdecide/hub/solver/do_solver/gphh.py
+++ b/skdecide/hub/solver/do_solver/gphh.py
@@ -516,36 +516,6 @@ class GPHH(Solver, DeterministicPolicies):
             else:
                 self.reference_permutations[td] = reference_permutations[td_name]
 
-    # def init_reference_makespans(self, reference_makespans={}, training_domains_names=[]) -> None:
-    #     self.reference_makespans = {}
-    #     for i in range(len(self.training_domains)):
-    #         td = self.training_domains[i]
-    #         td_name = training_domains_names[i]
-    #     # for td in self.training_domains:
-    #         print('td:',td)
-    #         if td_name not in reference_makespans.keys():
-    #             # Run CP
-    #             td.set_inplace_environment(False)
-    #             solver = DOSolver(policy_method_params=PolicyMethodParams(base_policy_method=BasePolicyMethod.FOLLOW_GANTT,
-    #                                                           delta_index_freedom=0,
-    #                                                           delta_time_freedom=0),
-    #                               method=SolvingMethod.CP)
-    #             solver.solve(domain_factory=lambda: td)
-    #
-    #             state = td.get_initial_state()
-    #             states, actions, values = rollout_episode(domain=td,
-    #                                                       max_steps=1000,
-    #                                                       solver=solver,
-    #                                                       from_memory=state,
-    #                                                       verbose=False,
-    #                                                       outcome_formatter=lambda
-    #                                                           o: f'{o.observation} - cost: {o.value.cost:.2f}')
-    #
-    #             makespan = sum([v.cost for v in values])
-    #             self.reference_makespans[td] = makespan
-    #         else:
-    #             self.reference_makespans[td] = reference_makespans[td_name]
-
     def _solve(self) -> None:
         self.domain = self._domain_factory()
 
@@ -712,41 +682,7 @@ class GPHH(Solver, DeterministicPolicies):
             vals.append(do_makespan)
 
         fitness = [np.mean(vals)]
-        # fitness = [np.max(vals)]
         return fitness
-
-    # def evaluate_heuristic_sgs_deviation(self, individual, domains) -> float:
-    #     vals = []
-    #     func_heuristic = self.toolbox.compile(expr=individual)
-    #     # selected_domains = random.sample(domains, 3)
-    #     selected_domains = domains
-    #
-    #     for domain in selected_domains:
-    #         policy = GPHHPolicy(domain, domain,
-    #                             func_heuristic,
-    #                             features=self.list_feature,
-    #                             params_gphh=self.params_gphh, recompute_cpm=False, cpm_data=self.cpm_data
-    #                             )
-    #         state = domain.get_initial_state().copy()
-    #         domain.set_inplace_environment(True)  # we can use True because we don't use the value
-    #
-    #         states, actions, values = rollout_episode(domain=domain,
-    #                                                   max_steps=10000,
-    #                                                   solver=policy,
-    #                                                   from_memory=state,
-    #                                                   verbose=False,
-    #                                                   outcome_formatter=lambda
-    #                                                       o: f'{o.observation} - cost: {o.value.cost:.2f}')
-    #
-    #         makespan = states[-1].t
-    #         ref_makespan = self.reference_makespans[domain]
-    #         makespan_deviation = (makespan - ref_makespan) / ref_makespan
-    #         # print('mk: ', makespan, ' - mk_dev: ', makespan_deviation, ' - ref: ', ref_makespan)
-    #         vals.append(makespan_deviation)
-    #
-    #     # fitness = [np.mean(vals)]
-    #     fitness = [np.mean(vals)]
-    #     return fitness
 
     def initialize_cpm_data_for_training(self):
         self.cpm_data = {}

--- a/skdecide/hub/solver/meta_policy_scheduling/meta_policies.py
+++ b/skdecide/hub/solver/meta_policy_scheduling/meta_policies.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
-from skdecide import rollout_episode
+from skdecide import rollout
 from skdecide.builders.domain.scheduling.scheduling_domains import D, SchedulingDomain
 from skdecide.builders.solver import DeterministicPolicies
 
@@ -62,14 +62,16 @@ class MetaPolicy(DeterministicPolicies):
             for method in self.policies:
                 results[method] = 0.0
                 for j in range(self.nb_rollout_estimation):
-                    states, actions, values = rollout_episode(
+                    states, actions, values = rollout(
                         domain=self.domain,
                         solver=self.policies[method],
                         outcome_formatter=None,
                         action_formatter=None,
                         verbose=False,
+                        goal_logging_level=logging.DEBUG,
                         from_memory=observation.copy(),
-                    )
+                        return_episodes=True,
+                    )[0]
                     results[method] += states[-1].t - observation.t
                     actions_map[method] = actions[0]
             if self.verbose:

--- a/skdecide/utils.py
+++ b/skdecide/utils.py
@@ -33,7 +33,6 @@ __all__ = [
     "load_registered_solver",
     "match_solvers",
     "rollout",
-    "rollout_episode",
 ]
 
 SKDECIDE_DEFAULT_DATAHOME = "~/skdecide_data"
@@ -150,7 +149,7 @@ def match_solvers(
 
 def rollout(
     domain: Domain,
-    solver: Optional[Solver] = None,
+    solver: Optional[Union[Solver, Policies]] = None,
     from_memory: Optional[D.T_memory[D.T_state]] = None,
     from_action: Optional[D.T_agent[D.T_concurrency[D.T_event]]] = None,
     num_episodes: int = 1,
@@ -160,7 +159,9 @@ def rollout(
     verbose: bool = True,
     action_formatter: Optional[Callable[[D.T_event], str]] = lambda a: str(a),
     outcome_formatter: Optional[Callable[[EnvironmentOutcome], str]] = lambda o: str(o),
-) -> None:
+    return_episodes: bool = False,
+    goal_logging_level: int = logging.INFO,
+) -> Optional[List[Tuple[List[D.T_observation], List[D.T_event], List[D.T_value]]]]:
     """This method will run one or more episodes in a domain according to the policy of a solver.
 
     # Parameters
@@ -175,7 +176,11 @@ def rollout(
     verbose: Whether to print information to the console during rollout.
     action_formatter: The function transforming actions in the string to print (if None, no print).
     outcome_formatter: The function transforming EnvironmentOutcome objects in the string to print (if None, no print).
+    return_episodes: if True, return the list of episodes, each episode as a tuple of observations, actions, and values.
+        else return nothing.
+    goal_logging_level: logging level at which we want to display if goal has been reached or not
     """
+    previous_log_level = logger.level
     if verbose:
         logger.setLevel(logging.DEBUG)
         logger.debug(
@@ -223,6 +228,14 @@ def rollout(
         solver = RandomWalk()
         autocast_all(solver, solver.T_domain, domain)
 
+    episodes: List[Tuple[List[D.T_observation], List[D.T_event], List[D.T_value]]] = []
+
+    if num_episodes > 1 and from_memory is None and not hasattr(domain, "reset"):
+        raise ValueError(
+            "If from_memory is not specified and domain has no reset() method, "
+            "num_episodes should be equal to 1."
+        )
+
     has_render = isinstance(domain, Renderable)
     has_goal = isinstance(domain, Goals)
     has_memory = not isinstance(domain, Markovian)
@@ -230,28 +243,43 @@ def rollout(
         # Initialize episode
         solver.reset()
         if from_memory is None:
-            observation = domain.reset()
+            if hasattr(domain, "reset"):
+                observation = domain.reset()
         else:
-            domain.set_memory(from_memory)
-            last_state = from_memory[-1] if has_memory else from_memory
-            observation = domain.get_observation_distribution(
-                last_state, from_action
-            ).sample()
+            if hasattr(domain, "set_memory"):
+                domain.set_memory(from_memory)
+                last_state = from_memory[-1] if has_memory else from_memory
+                observation = domain.get_observation_distribution(
+                    last_state, from_action
+                ).sample()
+            else:
+                raise ValueError(
+                    "from_memory must be None if domain has no set_memory() method."
+                )
         logger.debug(f"Episode {i_episode + 1} started with following observation:")
         logger.debug(observation)
         # Run episode
         step = 1
 
+        observations = []
+        actions = []
+        values = []
+        # save the initial observation
+        observations.append(observation)
+
         while max_steps is None or step <= max_steps:
             old_time = time.perf_counter()
             if render and has_render:
                 domain.render()
-            # assert solver.is_policy_defined_for(observation)
             action = solver.sample_action(observation)
             if action_formatter is not None:
                 logger.debug("Action: {}".format(action_formatter(action)))
             outcome = domain.step(action)
             observation = outcome.observation
+            if return_episodes:
+                observations.append(observation)
+                actions.append(action)
+                values.append(outcome.value)
             if outcome_formatter is not None:
                 logger.debug("Result: {}".format(outcome_formatter(outcome)))
             termination = (
@@ -272,144 +300,14 @@ def rollout(
         if render and has_render:
             domain.render()
         if has_goal:
-            logger.info(
+            logger.log(
+                goal_logging_level,
                 f'The goal was{"" if domain.is_goal(observation) else " not"} reached '
-                f"in episode {i_episode + 1}."
+                f"in episode {i_episode + 1}.",
             )
-
-
-def rollout_episode(
-    domain: Domain,
-    solver: Optional[Union[Solver, Policies]] = None,
-    from_memory: Optional[D.T_memory[D.T_state]] = None,
-    from_action: Optional[D.T_agent[D.T_concurrency[D.T_event]]] = None,
-    num_episodes: int = 1,
-    max_steps: Optional[int] = None,
-    render: bool = True,
-    max_framerate: Optional[float] = None,
-    verbose: bool = True,
-    action_formatter: Optional[Callable[[D.T_event], str]] = None,
-    outcome_formatter: Optional[Callable[[EnvironmentOutcome], str]] = None,
-) -> Tuple[List[D.T_observation], List[D.T_event], List[D.T_value]]:
-    """This method will run one or more episodes in a domain according to the policy of a solver.
-
-    # Parameters
-    domain: The domain in which the episode(s) will be run.
-    solver: The solver whose policy will select actions to take (if None, a random policy is used).
-    from_memory: The memory or state to consider as rollout starting point (if None, the domain is reset first).
-    from_action: The last applied action when from_memory is used (if necessary for initial observation computation).
-    num_episodes: The number of episodes to run.
-    max_steps: The maximum number of steps for each episode (if None, no limit is set).
-    render: Whether to render the episode(s) during rollout if the domain is renderable.
-    max_framerate: The maximum number of steps/renders per second (if None, steps/renders are never slowed down).
-    verbose: Whether to print information to the console during rollout.
-    action_formatter: The function transforming actions in the string to print (if None, no print).
-    outcome_formatter: The function transforming EnvironmentOutcome objects in the string to print (if None, no print).
-    """
+        if return_episodes:
+            episodes.append((observations, actions, values))
     if verbose:
-        logger.setLevel(logging.DEBUG)
-        logger.debug(
-            "Logger is in verbose mode: all debug messages will be there for you to enjoy （〜^∇^ )〜"
-        )
-
-    if solver is None:
-        # Create solver-like random walker that works for any domain
-        class RandomWalk(Policies):
-            T_domain = Domain
-            T_agent = Domain.T_agent
-            T_event = Domain.T_event
-
-            def __init__(self):
-                class CastDomain:  # trick to autocast domain's get_applicable_actions() without mutating domain
-                    T_agent = domain.T_agent
-                    T_event = domain.T_event
-
-                    @autocastable
-                    def get_applicable_actions(self) -> D.T_agent[Space[D.T_event]]:
-                        return domain.get_applicable_actions()
-
-                self._domain = CastDomain()
-                autocast_all(self._domain, self._domain, self)
-
-            @autocastable
-            def reset(self) -> None:
-                pass
-
-            @autocastable
-            def sample_action(
-                self, observation: D.T_agent[D.T_observation]
-            ) -> D.T_agent[D.T_concurrency[D.T_event]]:
-                return {
-                    agent: [space.sample()]
-                    for agent, space in self._domain.get_applicable_actions().items()
-                }
-
-            @autocastable
-            def is_policy_defined_for(
-                self, observation: D.T_agent[D.T_observation]
-            ) -> bool:
-                return True
-
-        solver = RandomWalk()
-        autocast_all(solver, solver.T_domain, domain)
-
-    has_render = isinstance(domain, Renderable)
-    has_goal = isinstance(domain, Goals)
-    has_memory = not isinstance(domain, Markovian)
-    for i_episode in range(num_episodes):
-        # Initialize episode
-        solver.reset()
-        if from_memory is None:
-            # observation = domain.reset()
-            pass
-        else:
-            domain.set_memory(from_memory)
-            last_state = from_memory[-1] if has_memory else from_memory
-            observation = domain.get_observation_distribution(
-                last_state, from_action
-            ).sample()
-        if verbose:
-            logger.debug(f"Episode {i_episode + 1} started with following observation:")
-            logger.debug(observation)
-        # Run episode
-        step = 1
-
-        observations = []
-        actions = []
-        values = []
-        # save the initial observation
-        observations.append(observation)
-
-        while max_steps is None or step <= max_steps:
-            old_time = time.perf_counter()
-            if render and has_render:
-                domain.render()
-            action = solver.sample_action(observation)
-            if action_formatter is not None:
-                logger.debug("Action: {}".format(action_formatter(action)))
-            domain.set_memory(observations[-1])
-            outcome = domain.step(action)
-            observation = outcome.observation
-            observations.append(observation)
-            actions.append(action)
-            values.append(outcome.value)
-            if outcome_formatter is not None:
-                logger.debug("Result: {}".format(outcome_formatter(outcome)))
-            if outcome.termination:
-                logger.debug(
-                    f"Episode {i_episode + 1} terminated after {step + 1} steps."
-                )
-                break
-            if max_framerate is not None:
-                wait = 1 / max_framerate - (time.perf_counter() - old_time)
-                if wait > 0:
-                    time.sleep(wait)
-            step += 1
-        if render and has_render:
-            domain.render()
-        if has_goal and verbose:
-            logger.info(
-                f'The goal was{"" if domain.is_goal(observation) else " not"} reached '
-                f"in episode {i_episode + 1}."
-            )
-        return observations, actions, values
+        logger.setLevel(previous_log_level)
+    if return_episodes:
+        return episodes

--- a/tests/scheduling/test_scheduling.py
+++ b/tests/scheduling/test_scheduling.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Set, Union
 import pytest
 from discrete_optimization.generic_tools.cp_tools import CPSolverName
 
-from skdecide import DiscreteDistribution, Distribution, rollout_episode
+from skdecide import DiscreteDistribution, Distribution, rollout
 from skdecide.builders.domain.scheduling.conditional_tasks import (
     WithoutConditionalTasks,
 )
@@ -476,7 +476,7 @@ class ToySimulatedCondSRCPSPDomain(
 )
 def test_rollout(domain, random_seed):
     state = domain.get_initial_state()
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=None,
@@ -484,7 +484,8 @@ def test_rollout(domain, random_seed):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     check_rollout_consistency(domain, states)
 
 
@@ -635,7 +636,7 @@ def test_do(domain, do_solver):
     )
     solver.solve()
     print(do_solver)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
@@ -643,7 +644,8 @@ def test_do(domain, do_solver):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     # action_formatter=lambda o: str(o),
     # outcome_formatter=lambda o: f'{o.observation} - cost: {o.value.cost:.2f}')
     check_rollout_consistency(domain, states)
@@ -674,7 +676,7 @@ def test_do_mskill(domain_multiskill, do_solver_multiskill):
     )
     solver.solve()
     print(do_solver_multiskill)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain_multiskill,
         max_steps=1000,
         solver=solver,
@@ -682,7 +684,8 @@ def test_do_mskill(domain_multiskill, do_solver_multiskill):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     check_rollout_consistency(domain_multiskill, states)
 
 
@@ -706,7 +709,7 @@ def test_planning_algos(domain, solver_str):
     if solver_str == "LazyAstar":
         solver = LazyAstar(domain_factory=lambda: domain, heuristic=None, verbose=False)
     solver.solve(from_memory=state)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
@@ -714,7 +717,8 @@ def test_planning_algos(domain, solver_str):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     check_rollout_consistency(domain, states)
 
 
@@ -734,7 +738,7 @@ def test_conditional_task_models(domain):
     np.random.seed(42)
     for i in range(n_rollout):
         state = domain.get_initial_state()
-        states, actions, values = rollout_episode(
+        states, actions, values = rollout(
             domain=domain,
             max_steps=1000,
             solver=None,
@@ -742,7 +746,8 @@ def test_conditional_task_models(domain):
             verbose=False,
             outcome_formatter=None,
             action_formatter=None,
-        )
+            return_episodes=True,
+        )[0]
         if (
             ConditionElementsExample.PROBLEM_OPERATION_2
             in states[-1]._current_conditions
@@ -782,7 +787,7 @@ def test_optimality(domain, do_solver):
     )
     solver.solve()
     print(do_solver)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
@@ -790,7 +795,8 @@ def test_optimality(domain, do_solver):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     tasks_complete_dict = rebuild_tasks_complete_details_dict(states[-1])
     makespan = max([tasks_complete_dict[x].end for x in states[-1].tasks_complete])
     if isinstance(domain, ToyRCPSPDomain):
@@ -823,7 +829,7 @@ def test_gecode_optimality(domain, do_solver):
     )
     solver.solve()
     print(do_solver)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
@@ -831,7 +837,8 @@ def test_gecode_optimality(domain, do_solver):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
 
     tasks_complete_dict = rebuild_tasks_complete_details_dict(states[-1])
     makespan = max([tasks_complete_dict[x].end for x in states[-1].tasks_complete])
@@ -911,7 +918,7 @@ def test_sgs_policies(domain):
     )
     solver.solve()
     solver.set_domain(domain)
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
@@ -919,7 +926,8 @@ def test_sgs_policies(domain):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     print("Cost :", sum([v.cost for v in values]))
     check_rollout_consistency(domain, states)
 
@@ -935,7 +943,7 @@ def test_sgs_policies(domain):
     )
     solver.solve()
     solver.set_domain(training_domains[0])
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=training_domains[0],
         max_steps=1000,
         solver=solver,
@@ -943,7 +951,8 @@ def test_sgs_policies(domain):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     print("Cost :", sum([v.cost for v in values]))
     check_rollout_consistency(domain, states)
 
@@ -993,7 +1002,7 @@ def test_do_with_cb(caplog):
 
     # action_formatter=lambda o: str(o),
     # outcome_formatter=lambda o: f'{o.observation} - cost: {o.value.cost:.2f}')
-    states, actions, values = rollout_episode(
+    states, actions, values = rollout(
         domain=domain,
         max_steps=1000,
         solver=solver,
@@ -1001,5 +1010,6 @@ def test_do_with_cb(caplog):
         action_formatter=None,
         outcome_formatter=None,
         verbose=False,
-    )
+        return_episodes=True,
+    )[0]
     check_rollout_consistency(domain, states)


### PR DESCRIPTION
This fixes #106

We merge rollout and rollout_episode together:
- add a return_episodes boolean arg to rollout, deciding wether to return episodes
- episodes are returned as a list of episodes, each episode being a tuple of observations, actions, and values (previously returned prematurely after one episode only one tuple even if num_episodes was >1)
- in rollout_episode, verbose=False was muting the logger.info("goal reached ..."), instead we introduce a parameter to change the level of this logging. So that in particular in MetaPolicy, we can relegate it at debug level.

Fix verbose behaviour by setting back logger level to previous level at the end of the rollout. (Previously was setting once for all the logger level to debug, even when going out of rollout.)