### PR TITLE
Build the doc with python 3.10

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -38,7 +38,7 @@ jobs:
   build-doc:
     runs-on: ubuntu-latest
     env:
-      python-version: "3.9"
+      python-version: "3.10"
     steps:
       - name: Set env variables for github links in doc
         run: |


### PR DESCRIPTION
Some parts of the documentation were not generated because they rely on dependencies which require python 3.10 (e.g. Unified Planning bindings), whereas the documention was generated with python 3.9.