### PR TITLE
Avoid closing domain of full_multisolve

### DIFF
--- a/examples/full_multisolve.py
+++ b/examples/full_multisolve.py
@@ -453,5 +453,8 @@ if __name__ == "__main__":
                     with solver_type(**selected_solver["config"]) as solver:
                         solver.solve()
                         rollout(actual_domain, solver, **selected_domain["rollout"])
+
                 if hasattr(domain, "close"):
-                    domain.close()
+                    # error when relaunching due to pygame.quit() called by classic control gymnasium environments
+                    # domain.close()
+                    pass


### PR DESCRIPTION
Some classic control environment from gymnasium call pygame.quit() when closing which prevents further rendering if relaunching an environment needed it and thus leading to an error.