### PR TITLE
Remove _init_solve

### DIFF
--- a/examples/gym_jsbsim_greedy.py
+++ b/examples/gym_jsbsim_greedy.py
@@ -105,19 +105,18 @@ class GreedyPlanner(Solver, DeterministicPolicies, Utilities, FromAnyState):
 
     def __init__(self, domain_factory: Callable[[], Domain]):
         Solver.__init__(self, domain_factory=domain_factory)
-        self._domain = None
-        self._best_action = None
-        self._best_reward = None
-        self._current_pos = None
-
-    def _init_solve(self) -> None:
         self._domain = self._domain_factory()
         self._domain.reset()
         lon = self._domain._gym_env.sim.get_property_value(prp.position_long_gc_deg)
         lat = self._domain._gym_env.sim.get_property_value(prp.position_lat_geod_deg)
         self._current_pos = (lat, lon)
+        self._best_action = None
+        self._best_reward = None
 
     def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:
+        if self._domain is None:
+            self._domain = self._domain_factory()
+            self._domain.reset()
         self._best_action = None
         self._best_reward = -float("inf")
         self._current_pos = None

--- a/skdecide/builders/solver/fromanystatesolvability.py
+++ b/skdecide/builders/solver/fromanystatesolvability.py
@@ -83,7 +83,6 @@ class FromAnyState(FromInitialState):
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
         """
-        self._init_solve()
         if from_memory is None:
             domain = self._domain_factory()
             if not isinstance(domain, Initializable):
@@ -98,9 +97,6 @@ class FromAnyState(FromInitialState):
     @autocastable
     def solve_from(self, memory: D.T_memory[D.T_state]) -> None:
         """Run the solving process from a given state.
-
-        !!! tip
-            Create the domain first by calling the @FromAnyState.init_solve() method
 
         After solving by calling self._solve_from(), autocast itself so that rollout methods apply
         to the domain original characteristics.
@@ -118,22 +114,11 @@ class FromAnyState(FromInitialState):
     def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:
         """Run the solving process from a given state.
 
-        !!! tip
-            Create the domain first by calling the @FromAnyState._init_solve() method
-
         # Parameters
         memory: The source memory (state or history) of the transition.
 
         !!! tip
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
-        """
-        raise NotImplementedError
-
-    def _init_solve(self) -> None:
-        """Initialize solver before calling `solve_from()`
-
-        In particular, initialize the underlying domain.
-
         """
         raise NotImplementedError

--- a/skdecide/builders/solver/parallelability.py
+++ b/skdecide/builders/solver/parallelability.py
@@ -32,7 +32,7 @@ class ParallelSolver:
 
     def _initialize(self):
         """Launches the parallel domains.
-        This method requires to have previously recorded the self._domain_factory (e.g. after calling _init_solve),
+        This method requires to have previously recorded the self._domain_factory (e.g. after calling Solver.__init__()),
         the set of lambda functions passed to the solver's constructor (e.g. heuristic lambda for heuristic-based solvers),
         and whether the parallel domain jobs should notify their status via the IPC protocol (required when interacting with
         other programming languages like C++)

--- a/skdecide/hub/solver/aostar/aostar.py
+++ b/skdecide/hub/solver/aostar/aostar.py
@@ -104,15 +104,25 @@ try:
                 shared_memory_proxy=shared_memory_proxy,
             )
             Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._discount = discount
-            self._max_tip_expansions = max_tip_expansions
-            self._detect_cycles = detect_cycles
-            self._heuristic = heuristic
-            self._lambdas = [self._heuristic]
-            self._callback = callback
-            self._verbose = verbose
+            self._lambdas = [heuristic]
             self._ipc_notify = True
+
+            self._solver = aostar_solver(
+                solver=self,
+                domain=self.get_domain(),
+                goal_checker=lambda d, s: d.is_goal(s),
+                heuristic=(
+                    (lambda d, s: heuristic(d, s))
+                    if not parallel
+                    else (lambda d, s: d.call(None, 0, s))
+                ),
+                discount=discount,
+                max_tip_expansions=max_tip_expansions,
+                detect_cycles=detect_cycles,
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -125,25 +135,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = aostar_solver(
-                solver=self,
-                domain=self.get_domain(),
-                goal_checker=lambda d, s: d.is_goal(s),
-                heuristic=(
-                    (lambda d, s: self._heuristic(d, s))
-                    if not self._parallel
-                    else (lambda d, s: d.call(None, 0, s))
-                ),
-                discount=self._discount,
-                max_tip_expansions=self._max_tip_expansions,
-                detect_cycles=self._detect_cycles,
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/astar/astar.py
+++ b/skdecide/hub/solver/astar/astar.py
@@ -93,12 +93,22 @@ try:
                 shared_memory_proxy=shared_memory_proxy,
             )
             Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._heuristic = heuristic
-            self._lambdas = [self._heuristic]
-            self._callback = callback
-            self._verbose = verbose
+            self._lambdas = [heuristic]
             self._ipc_notify = True
+
+            self._solver = astar_solver(
+                solver=self,
+                domain=self.get_domain(),
+                goal_checker=lambda d, s: d.is_goal(s),
+                heuristic=(
+                    (lambda d, s: heuristic(d, s))
+                    if not parallel
+                    else (lambda d, s: d.call(None, 0, s))
+                ),
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -108,22 +118,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = astar_solver(
-                solver=self,
-                domain=self.get_domain(),
-                goal_checker=lambda d, s: d.is_goal(s),
-                heuristic=(
-                    (lambda d, s: self._heuristic(d, s))
-                    if not self._parallel
-                    else (lambda d, s: d.call(None, 0, s))
-                ),
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/ilaostar/ilaostar.py
+++ b/skdecide/hub/solver/ilaostar/ilaostar.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Set, Tuple
 
 from skdecide import Domain, Solver, hub
 from skdecide.builders.domain import (
@@ -100,14 +100,24 @@ try:
                 shared_memory_proxy=shared_memory_proxy,
             )
             Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._discount = discount
-            self._epsilon = epsilon
-            self._heuristic = heuristic
-            self._lambdas = [self._heuristic]
-            self._callback = callback
-            self._verbose = verbose
+            self._lambdas = [heuristic]
             self._ipc_notify = True
+
+            self._solver = ilaostar_solver(
+                solver=self,
+                domain=self.get_domain(),
+                goal_checker=lambda d, s: d.is_goal(s),
+                heuristic=(
+                    (lambda d, s: heuristic(d, s))
+                    if not parallel
+                    else (lambda d, s: d.call(None, 0, s))
+                ),
+                discount=discount,
+                epsilon=epsilon,
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -117,22 +127,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = ilaostar_solver(
-                solver=self,
-                domain=self.get_domain(),
-                goal_checker=lambda d, s: d.is_goal(s),
-                heuristic=lambda d, s: (
-                    self._heuristic(d, s) if not self._parallel else d.call(None, 0, s)
-                ),
-                discount=self._discount,
-                epsilon=self._epsilon,
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/iw/iw.py
+++ b/skdecide/hub/solver/iw/iw.py
@@ -103,16 +103,24 @@ try:
                 shared_memory_proxy=shared_memory_proxy,
             )
             Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._domain = None
-            self._state_features = state_features
-            self._use_state_feature_hash = use_state_feature_hash
-            self._node_ordering = node_ordering
-            self._time_budget = time_budget
-            self._lambdas = [self._state_features]
-            self._callback = callback
-            self._verbose = verbose
+            self._lambdas = [state_features]
             self._ipc_notify = True
+
+            self._solver = iw_solver(
+                solver=self,
+                domain=self.get_domain(),
+                state_features=(
+                    (lambda d, s: state_features(d, s))
+                    if not self._parallel
+                    else (lambda d, s: d.call(None, 0, s))
+                ),
+                use_state_feature_hash=use_state_feature_hash,
+                node_ordering=node_ordering,
+                time_budget=time_budget,
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -122,24 +130,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = iw_solver(
-                solver=self,
-                domain=self.get_domain(),
-                state_features=(
-                    (lambda d, s: self._state_features(d, s))
-                    if not self._parallel
-                    else (lambda d, s: d.call(None, 0, s))
-                ),
-                use_state_feature_hash=self._use_state_feature_hash,
-                node_ordering=self._node_ordering,
-                time_budget=self._time_budget,
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/lazy_astar/lazy_astar.py
+++ b/skdecide/hub/solver/lazy_astar/lazy_astar.py
@@ -66,6 +66,7 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """
         self.callback = callback
         Solver.__init__(self, domain_factory=domain_factory)
+        self._domain = self._domain_factory()
         self._heuristic = (
             (lambda _, __: Value(cost=0.0)) if heuristic is None else heuristic
         )
@@ -83,22 +84,11 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """Return the computed policy."""
         return self._policy
 
-    def _init_solve(self) -> None:
-        """Initialize solver before calling `solve_from()`
-
-        In particular, initialize the underlying domain.
-
-        """
-        self._domain = self._domain_factory()
-
     def _solve_from(
         self,
         memory: D.T_state,
     ) -> None:
         """Run the solving process from a given state.
-
-        !!! tip
-            Create the domain first by calling the @FromAnyState._init_solve() method
 
         # Parameters
         memory: The source memory (state or history) of the transition.

--- a/skdecide/hub/solver/lrtastar/lrtastar.py
+++ b/skdecide/hub/solver/lrtastar/lrtastar.py
@@ -79,6 +79,7 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """
         self.callback = callback
         Solver.__init__(self, domain_factory=domain_factory)
+        self._domain = self._domain_factory()
         self._heuristic = (
             (lambda _, __: Value(cost=0.0)) if heuristic is None else heuristic
         )
@@ -97,22 +98,11 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """Return the computed policy."""
         return self._policy
 
-    def _init_solve(self) -> None:
-        """Initialize solver before calling `solve_from()`
-
-        In particular, initialize the underlying domain.
-
-        """
-        self._domain = self._domain_factory()
-
     def _solve_from(
         self,
         memory: D.T_state,
     ) -> None:
         """Run the solving process from a given state.
-
-        !!! tip
-            Create the domain first by calling the @FromAnyState._init_solve() method
 
         # Parameters
         memory: The source memory (state or history) of the transition.

--- a/skdecide/hub/solver/mahd/mahd.py
+++ b/skdecide/hub/solver/mahd/mahd.py
@@ -122,7 +122,6 @@ class MAHD(Solver, DeterministicPolicies, Utilities, FromAnyState):
             self._singleagent_solvers[a] = self._singleagent_solver_class(
                 **singleagent_solver_kwargs
             )
-            self._singleagent_solvers[a]._init_solve(),
 
         self._singleagent_solutions = {
             a: {} for a in self._multiagent_domain.get_agents()
@@ -137,10 +136,6 @@ class MAHD(Solver, DeterministicPolicies, Utilities, FromAnyState):
         self._multiagent_solver._solve_from(
             memory=memory,
         )
-
-    def _init_solve(self) -> None:
-        """Initializes the higher-level multi-agent solving process"""
-        self._multiagent_solver._init_solve()
 
     def _get_next_action(
         self, observation: D.T_agent[D.T_observation]

--- a/skdecide/hub/solver/martdp/martdp.py
+++ b/skdecide/hub/solver/martdp/martdp.py
@@ -133,45 +133,28 @@ try:
 
             Solver.__init__(self, domain_factory=domain_factory)
             self._domain = self._domain_factory()
-            self._solver = None
-            self._heuristic = heuristic
-            self._time_budget = time_budget
-            self._rollout_budget = rollout_budget
-            self._max_depth = max_depth
-            self._max_feasibility_trials = max_feasibility_trials
-            self._graph_expansion_rate = graph_expansion_rate
-            self._residual_moving_average_window = residual_moving_average_window
-            self._epsilon = epsilon
-            self._discount = discount
-            self._action_choice_noise = action_choice_noise
-            self._dead_end_cost = dead_end_cost
-            self._online_node_garbage = online_node_garbage
             self._continuous_planning = continuous_planning
-            self._callback = callback
-            self._verbose = verbose
             self._ipc_notify = True
 
-        def _init_solve(self) -> None:
             self._solver = martdp_solver(
                 solver=self,
                 domain=self.get_domain(),
                 goal_checker=lambda d, s: d.is_goal(s),
-                heuristic=lambda d, s: self._heuristic(d, s),
-                time_budget=self._time_budget,
-                rollout_budget=self._rollout_budget,
-                max_depth=self._max_depth,
-                max_feasibility_trials=self._max_feasibility_trials,
-                graph_expansion_rate=self._graph_expansion_rate,
-                residual_moving_average_window=self._residual_moving_average_window,
-                epsilon=self._epsilon,
-                discount=self._discount,
-                action_choice_noise=self._action_choice_noise,
-                dead_end_cost=self._dead_end_cost,
-                online_node_garbage=self._online_node_garbage,
-                callback=self._callback,
-                verbose=self._verbose,
+                heuristic=lambda d, s: heuristic(d, s),
+                time_budget=time_budget,
+                rollout_budget=rollout_budget,
+                max_depth=max_depth,
+                max_feasibility_trials=max_feasibility_trials,
+                graph_expansion_rate=graph_expansion_rate,
+                residual_moving_average_window=residual_moving_average_window,
+                epsilon=epsilon,
+                discount=discount,
+                action_choice_noise=action_choice_noise,
+                dead_end_cost=dead_end_cost,
+                online_node_garbage=online_node_garbage,
+                callback=callback,
+                verbose=verbose,
             )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/mcts/mcts.py
+++ b/skdecide/hub/solver/mcts/mcts.py
@@ -219,30 +219,52 @@ try:
             Solver.__init__(self, domain_factory=domain_factory)
             self._solver = None
             self._domain = None
-            self._time_budget = time_budget
-            self._rollout_budget = rollout_budget
-            self._max_depth = max_depth
-            self._residual_moving_average_window = residual_moving_average_window
-            self._epsilon = epsilon
-            self._discount = discount
-            self._ucb_constant = ucb_constant
-            self._online_node_garbage = online_node_garbage
-            self._custom_policy = custom_policy
-            self._heuristic = heuristic
-            self._state_expansion_rate = state_expansion_rate
-            self._action_expansion_rate = action_expansion_rate
-            self._transition_mode = transition_mode
-            self._tree_policy = tree_policy
-            self._expander = expander
-            self._action_selector_optimization = action_selector_optimization
-            self._action_selector_execution = action_selector_execution
-            self._rollout_policy = rollout_policy
-            self._back_propagator = back_propagator
             self._continuous_planning = continuous_planning
-            self._callback = callback
-            self._verbose = verbose
-            self._lambdas = [self._custom_policy, self._heuristic]
+            self._lambdas = [custom_policy, heuristic]
             self._ipc_notify = True
+
+            self._solver = mcts_solver(
+                solver=self,
+                domain=self.get_domain(),
+                time_budget=time_budget,
+                rollout_budget=rollout_budget,
+                max_depth=max_depth,
+                residual_moving_average_window=residual_moving_average_window,
+                epsilon=epsilon,
+                discount=discount,
+                ucb_constant=ucb_constant,
+                online_node_garbage=online_node_garbage,
+                custom_policy=(
+                    None
+                    if custom_policy is None
+                    else (
+                        (lambda d, s, i=None: custom_policy(d, s))
+                        if not parallel
+                        else (lambda d, s, i=None: d.call(i, 0, s))
+                    )
+                ),
+                heuristic=(
+                    None
+                    if heuristic is None
+                    else (
+                        (lambda d, s, i=None: heuristic(d, s))
+                        if not parallel
+                        else (lambda d, s, i=None: d.call(i, 1, s))
+                    )
+                ),
+                state_expansion_rate=state_expansion_rate,
+                action_expansion_rate=action_expansion_rate,
+                transition_mode=transition_mode.value,
+                tree_policy=tree_policy.value,
+                expander=expander.value,
+                action_selector_optimization=action_selector_optimization.value,
+                action_selector_execution=action_selector_execution.value,
+                rollout_policy=rollout_policy.value,
+                back_propagator=back_propagator.value,
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -252,51 +274,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = mcts_solver(
-                solver=self,
-                domain=self.get_domain(),
-                time_budget=self._time_budget,
-                rollout_budget=self._rollout_budget,
-                max_depth=self._max_depth,
-                residual_moving_average_window=self._residual_moving_average_window,
-                epsilon=self._epsilon,
-                discount=self._discount,
-                ucb_constant=self._ucb_constant,
-                online_node_garbage=self._online_node_garbage,
-                custom_policy=(
-                    None
-                    if self._custom_policy is None
-                    else (
-                        (lambda d, s, i=None: self._custom_policy(d, s))
-                        if not self._parallel
-                        else (lambda d, s, i=None: d.call(i, 0, s))
-                    )
-                ),
-                heuristic=(
-                    None
-                    if self._heuristic is None
-                    else (
-                        (lambda d, s, i=None: self._heuristic(d, s))
-                        if not self._parallel
-                        else (lambda d, s, i=None: d.call(i, 1, s))
-                    )
-                ),
-                state_expansion_rate=self._state_expansion_rate,
-                action_expansion_rate=self._action_expansion_rate,
-                transition_mode=self._transition_mode.value,
-                tree_policy=self._tree_policy.value,
-                expander=self._expander.value,
-                action_selector_optimization=self._action_selector_optimization.value,
-                action_selector_execution=self._action_selector_execution.value,
-                rollout_policy=self._rollout_policy.value,
-                back_propagator=self._back_propagator.value,
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""
@@ -602,8 +579,9 @@ try:
             self._action_choice_noise = action_choice_noise
             self._heuristic_records = {}
 
-        def _init_solve(self) -> None:
-            super()._init_solve()
+        def _reset(self) -> None:
+            """Clears the search graph and the heuristic records."""
+            super()._reset()
             self._heuristic_records = {}
 
         def _value_heuristic(


### PR DESCRIPTION
This PR:
- Remove _init_solve() in the solvers which was not consistently used between the FromInitialState solvers (which did not use it to be initialized before the solve()) and FromAnyState solvers (which had to call it to be initialized before the solve()) ;
- Now construct the C++ solvers in their Python interfaces' constructors instead of in _init_solve(), which has the additional benefits of:
   - removing the exception thrown when the methods calling the C++ solvers were not first initialized through a call to the solve() method beforehand ;
   - being able to reuse search objects of the C++ solver from previous calls to the solve(from_state) method instead of reconstructing the C++ solver in the _init_solve() method which was previously called at each start of the solve(from_state) method