### PR TITLE
Remove _init_solve()

### DIFF
--- a/examples/gym_jsbsim_greedy.py
+++ b/examples/gym_jsbsim_greedy.py
@@ -105,19 +105,18 @@ class GreedyPlanner(Solver, DeterministicPolicies, Utilities, FromAnyState):
 
     def __init__(self, domain_factory: Callable[[], Domain]):
         Solver.__init__(self, domain_factory=domain_factory)
-        self._domain = None
-        self._best_action = None
-        self._best_reward = None
-        self._current_pos = None
-
-    def _init_solve(self) -> None:
         self._domain = self._domain_factory()
         self._domain.reset()
         lon = self._domain._gym_env.sim.get_property_value(prp.position_long_gc_deg)
         lat = self._domain._gym_env.sim.get_property_value(prp.position_lat_geod_deg)
         self._current_pos = (lat, lon)
+        self._best_action = None
+        self._best_reward = None
 
     def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:
+        if self._domain is None:
+            self._domain = self._domain_factory()
+            self._domain.reset()
         self._best_action = None
         self._best_reward = -float("inf")
         self._current_pos = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scikit-decide"
-version = "0.0.0" # placeholder for poetry-dynamic-versioning
+version = "1.0.1.dev8+88ac7d6f" # placeholder for poetry-dynamic-versioning
 description = "The AI framework for Reinforcement Learning, Automated Planning and Scheduling"
 authors = ["Airbus AI Research <scikit-decide@airbus.com>"]
 license = "MIT"
@@ -36,7 +36,7 @@ script = "builder.py"
 generate-setup-file = true
 
 [tool.poetry-dynamic-versioning]
-enable = true
+enable = false
 vcs = "git"
 format-jinja = """
     {%- if distance == 0 -%}

--- a/skdecide/__init__.py
+++ b/skdecide/__init__.py
@@ -8,4 +8,4 @@ from skdecide.domains import *
 from skdecide.solvers import *
 from skdecide.utils import *
 
-__version__ = "0.0.0"
+__version__ = "1.0.1.dev8+88ac7d6f"

--- a/skdecide/builders/solver/fromanystatesolvability.py
+++ b/skdecide/builders/solver/fromanystatesolvability.py
@@ -83,7 +83,6 @@ class FromAnyState(FromInitialState):
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
         """
-        self._init_solve()
         if from_memory is None:
             domain = self._domain_factory()
             if not isinstance(domain, Initializable):
@@ -98,9 +97,6 @@ class FromAnyState(FromInitialState):
     @autocastable
     def solve_from(self, memory: D.T_memory[D.T_state]) -> None:
         """Run the solving process from a given state.
-
-        !!! tip
-            Create the domain first by calling the @FromAnyState.init_solve() method
 
         After solving by calling self._solve_from(), autocast itself so that rollout methods apply
         to the domain original characteristics.
@@ -118,22 +114,11 @@ class FromAnyState(FromInitialState):
     def _solve_from(self, memory: D.T_memory[D.T_state]) -> None:
         """Run the solving process from a given state.
 
-        !!! tip
-            Create the domain first by calling the @FromAnyState._init_solve() method
-
         # Parameters
         memory: The source memory (state or history) of the transition.
 
         !!! tip
             The nature of the solutions produced here depends on other solver's characteristics like
             #policy and #assessibility.
-        """
-        raise NotImplementedError
-
-    def _init_solve(self) -> None:
-        """Initialize solver before calling `solve_from()`
-
-        In particular, initialize the underlying domain.
-
         """
         raise NotImplementedError

--- a/skdecide/builders/solver/parallelability.py
+++ b/skdecide/builders/solver/parallelability.py
@@ -20,9 +20,13 @@ class ParallelSolver:
         shared_memory_proxy=None,
     ):
         """Creates a parallelizable solver
+
         # Parameters
         parallel: True if the solver is run in parallel mode.
         shared_memory_proxy: Shared memory proxy to use if not None, otherwise run piped parallel domains.
+
+
+
         """
         self._parallel = parallel
         self._shared_memory_proxy = shared_memory_proxy
@@ -32,7 +36,7 @@ class ParallelSolver:
 
     def _initialize(self):
         """Launches the parallel domains.
-        This method requires to have previously recorded the self._domain_factory (e.g. after calling _init_solve),
+        This method requires to have previously recorded the self._domain_factory,
         the set of lambda functions passed to the solver's constructor (e.g. heuristic lambda for heuristic-based solvers),
         and whether the parallel domain jobs should notify their status via the IPC protocol (required when interacting with
         other programming languages like C++)

--- a/skdecide/hub/solver/aostar/aostar.py
+++ b/skdecide/hub/solver/aostar/aostar.py
@@ -98,21 +98,31 @@ try:
             verbose (bool, optional): Boolean indicating whether verbose messages should be
                 logged (True) or not (False). Defaults to False.
             """
+            Solver.__init__(self, domain_factory=domain_factory)
             ParallelSolver.__init__(
                 self,
                 parallel=parallel,
                 shared_memory_proxy=shared_memory_proxy,
             )
-            Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._discount = discount
-            self._max_tip_expansions = max_tip_expansions
-            self._detect_cycles = detect_cycles
-            self._heuristic = heuristic
-            self._lambdas = [self._heuristic]
-            self._callback = callback
-            self._verbose = verbose
+            self._lambdas = [heuristic]
             self._ipc_notify = True
+
+            self._solver = aostar_solver(
+                solver=self,
+                domain=self.get_domain(),
+                goal_checker=lambda d, s: d.is_goal(s),
+                heuristic=(
+                    (lambda d, s: heuristic(d, s))
+                    if not parallel
+                    else (lambda d, s: d.call(None, 0, s))
+                ),
+                discount=discount,
+                max_tip_expansions=max_tip_expansions,
+                detect_cycles=detect_cycles,
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -125,25 +135,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = aostar_solver(
-                solver=self,
-                domain=self.get_domain(),
-                goal_checker=lambda d, s: d.is_goal(s),
-                heuristic=(
-                    (lambda d, s: self._heuristic(d, s))
-                    if not self._parallel
-                    else (lambda d, s: d.call(None, 0, s))
-                ),
-                discount=self._discount,
-                max_tip_expansions=self._max_tip_expansions,
-                detect_cycles=self._detect_cycles,
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/astar/astar.py
+++ b/skdecide/hub/solver/astar/astar.py
@@ -87,18 +87,28 @@ try:
             verbose (bool, optional): Boolean indicating whether verbose messages should be
                 logged (True) or not (False). Defaults to False.
             """
+            Solver.__init__(self, domain_factory=domain_factory)
             ParallelSolver.__init__(
                 self,
                 parallel=parallel,
                 shared_memory_proxy=shared_memory_proxy,
             )
-            Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._heuristic = heuristic
-            self._lambdas = [self._heuristic]
-            self._callback = callback
-            self._verbose = verbose
+            self._lambdas = [heuristic]
             self._ipc_notify = True
+
+            self._solver = astar_solver(
+                solver=self,
+                domain=self.get_domain(),
+                goal_checker=lambda d, s: d.is_goal(s),
+                heuristic=(
+                    (lambda d, s: heuristic(d, s))
+                    if not parallel
+                    else (lambda d, s: d.call(None, 0, s))
+                ),
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -108,22 +118,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = astar_solver(
-                solver=self,
-                domain=self.get_domain(),
-                goal_checker=lambda d, s: d.is_goal(s),
-                heuristic=(
-                    (lambda d, s: self._heuristic(d, s))
-                    if not self._parallel
-                    else (lambda d, s: d.call(None, 0, s))
-                ),
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/bfws/bfws.py
+++ b/skdecide/hub/solver/bfws/bfws.py
@@ -88,23 +88,36 @@ try:
             verbose (bool, optional): Boolean indicating whether verbose messages should be
                 logged (True) or not (False). Defaults to False.
             """
+            Solver.__init__(self, domain_factory=domain_factory)
             ParallelSolver.__init__(
                 self,
                 parallel=parallel,
                 shared_memory_proxy=shared_memory_proxy,
             )
-            Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._domain = None
-            self._state_features = state_features
-            self._heuristic = heuristic
             self._lambdas = [
-                self._state_features,
-                self._heuristic,
+                state_features,
+                heuristic,
             ]
-            self._callback = callback
-            self._verbose = verbose
             self._ipc_notify = True
+
+            self._solver = bfws_solver(
+                solver=self,
+                domain=self.get_domain(),
+                goal_checker=lambda d, s: d.is_goal(s),
+                state_features=(
+                    (lambda d, s: state_features(d, s))
+                    if not parallel
+                    else (lambda d, s: d.call(None, 0, s))
+                ),
+                heuristic=(
+                    (lambda d, s: heuristic(d, s))
+                    if not parallel
+                    else (lambda d, s: d.call(None, 1, s))
+                ),
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -114,27 +127,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = bfws_solver(
-                solver=self,
-                domain=self.get_domain(),
-                goal_checker=lambda d, s: d.is_goal(s),
-                state_features=(
-                    (lambda d, s: self._state_features(d, s))
-                    if not self._parallel
-                    else (lambda d, s: d.call(None, 0, s))
-                ),
-                heuristic=(
-                    (lambda d, s: self._heuristic(d, s))
-                    if not self._parallel
-                    else (lambda d, s: d.call(None, 1, s))
-                ),
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/lazy_astar/lazy_astar.py
+++ b/skdecide/hub/solver/lazy_astar/lazy_astar.py
@@ -66,6 +66,7 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """
         self.callback = callback
         Solver.__init__(self, domain_factory=domain_factory)
+        self._domain = self._domain_factory()
         self._heuristic = (
             (lambda _, __: Value(cost=0.0)) if heuristic is None else heuristic
         )
@@ -83,22 +84,11 @@ class LazyAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """Return the computed policy."""
         return self._policy
 
-    def _init_solve(self) -> None:
-        """Initialize solver before calling `solve_from()`
-
-        In particular, initialize the underlying domain.
-
-        """
-        self._domain = self._domain_factory()
-
     def _solve_from(
         self,
         memory: D.T_state,
     ) -> None:
         """Run the solving process from a given state.
-
-        !!! tip
-            Create the domain first by calling the @FromAnyState._init_solve() method
 
         # Parameters
         memory: The source memory (state or history) of the transition.

--- a/skdecide/hub/solver/lrtastar/lrtastar.py
+++ b/skdecide/hub/solver/lrtastar/lrtastar.py
@@ -79,6 +79,7 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """
         self.callback = callback
         Solver.__init__(self, domain_factory=domain_factory)
+        self._domain = self._domain_factory()
         self._heuristic = (
             (lambda _, __: Value(cost=0.0)) if heuristic is None else heuristic
         )
@@ -97,22 +98,11 @@ class LRTAstar(Solver, DeterministicPolicies, Utilities, FromAnyState):
         """Return the computed policy."""
         return self._policy
 
-    def _init_solve(self) -> None:
-        """Initialize solver before calling `solve_from()`
-
-        In particular, initialize the underlying domain.
-
-        """
-        self._domain = self._domain_factory()
-
     def _solve_from(
         self,
         memory: D.T_state,
     ) -> None:
         """Run the solving process from a given state.
-
-        !!! tip
-            Create the domain first by calling the @FromAnyState._init_solve() method
 
         # Parameters
         memory: The source memory (state or history) of the transition.

--- a/skdecide/hub/solver/lrtdp/lrtdp.py
+++ b/skdecide/hub/solver/lrtdp/lrtdp.py
@@ -123,27 +123,41 @@ try:
             verbose (bool, optional): Boolean indicating whether verbose messages should be logged (True)
                 or not (False). Defaults to False.
             """
+            Solver.__init__(self, domain_factory=domain_factory)
             ParallelSolver.__init__(
                 self,
                 parallel=parallel,
                 shared_memory_proxy=shared_memory_proxy,
             )
-            Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._heuristic = heuristic
-            self._lambdas = [self._heuristic]
-            self._use_labels = use_labels
-            self._time_budget = time_budget
-            self._rollout_budget = rollout_budget
-            self._max_depth = max_depth
-            self._residual_moving_average_window = residual_moving_average_window
-            self._epsilon = epsilon
-            self._discount = discount
-            self._online_node_garbage = online_node_garbage
+            self._lambdas = [heuristic]
             self._continuous_planning = continuous_planning
-            self._callback = callback
-            self._verbose = verbose
             self._ipc_notify = True
+
+            self._solver = lrtdp_solver(
+                solver=self,
+                domain=self.get_domain(),
+                goal_checker=(
+                    (lambda d, s, i=None: d.is_goal(s))
+                    if not parallel
+                    else (lambda d, s, i=None: d.is_goal(s, i))
+                ),
+                heuristic=(
+                    (lambda d, s, i=None: heuristic(d, s))
+                    if not parallel
+                    else (lambda d, s, i=None: d.call(i, 0, s))
+                ),
+                use_labels=use_labels,
+                time_budget=time_budget,
+                rollout_budget=rollout_budget,
+                max_depth=max_depth,
+                residual_moving_average_window=residual_moving_average_window,
+                epsilon=epsilon,
+                discount=discount,
+                online_node_garbage=online_node_garbage,
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -156,34 +170,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = lrtdp_solver(
-                solver=self,
-                domain=self.get_domain(),
-                goal_checker=(
-                    (lambda d, s, i=None: d.is_goal(s))
-                    if not self._parallel
-                    else (lambda d, s, i=None: d.is_goal(s, i))
-                ),
-                heuristic=(
-                    (lambda d, s, i=None: self._heuristic(d, s))
-                    if not self._parallel
-                    else (lambda d, s, i=None: d.call(i, 0, s))
-                ),
-                use_labels=self._use_labels,
-                time_budget=self._time_budget,
-                rollout_budget=self._rollout_budget,
-                max_depth=self._max_depth,
-                residual_moving_average_window=self._residual_moving_average_window,
-                epsilon=self._epsilon,
-                discount=self._discount,
-                online_node_garbage=self._online_node_garbage,
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/mahd/mahd.py
+++ b/skdecide/hub/solver/mahd/mahd.py
@@ -122,7 +122,6 @@ class MAHD(Solver, DeterministicPolicies, Utilities, FromAnyState):
             self._singleagent_solvers[a] = self._singleagent_solver_class(
                 **singleagent_solver_kwargs
             )
-            self._singleagent_solvers[a]._init_solve(),
 
         self._singleagent_solutions = {
             a: {} for a in self._multiagent_domain.get_agents()
@@ -137,10 +136,6 @@ class MAHD(Solver, DeterministicPolicies, Utilities, FromAnyState):
         self._multiagent_solver._solve_from(
             memory=memory,
         )
-
-    def _init_solve(self) -> None:
-        """Initializes the higher-level multi-agent solving process"""
-        self._multiagent_solver._init_solve()
 
     def _get_next_action(
         self, observation: D.T_agent[D.T_observation]

--- a/skdecide/hub/solver/martdp/martdp.py
+++ b/skdecide/hub/solver/martdp/martdp.py
@@ -131,45 +131,28 @@ try:
 
             Solver.__init__(self, domain_factory=domain_factory)
             self._domain = self._domain_factory()
-            self._solver = None
-            self._heuristic = heuristic
-            self._time_budget = time_budget
-            self._rollout_budget = rollout_budget
-            self._max_depth = max_depth
-            self._max_feasibility_trials = max_feasibility_trials
-            self._graph_expansion_rate = graph_expansion_rate
-            self._residual_moving_average_window = residual_moving_average_window
-            self._epsilon = epsilon
-            self._discount = discount
-            self._action_choice_noise = action_choice_noise
-            self._dead_end_cost = dead_end_cost
-            self._online_node_garbage = online_node_garbage
             self._continuous_planning = continuous_planning
-            self._callback = callback
-            self._verbose = verbose
             self._ipc_notify = True
 
-        def _init_solve(self) -> None:
             self._solver = martdp_solver(
                 solver=self,
                 domain=self.get_domain(),
                 goal_checker=lambda d, s: d.is_goal(s),
-                heuristic=lambda d, s: self._heuristic(d, s),
-                time_budget=self._time_budget,
-                rollout_budget=self._rollout_budget,
-                max_depth=self._max_depth,
-                max_feasibility_trials=self._max_feasibility_trials,
-                graph_expansion_rate=self._graph_expansion_rate,
-                residual_moving_average_window=self._residual_moving_average_window,
-                epsilon=self._epsilon,
-                discount=self._discount,
-                action_choice_noise=self._action_choice_noise,
-                dead_end_cost=self._dead_end_cost,
-                online_node_garbage=self._online_node_garbage,
-                callback=self._callback,
-                verbose=self._verbose,
+                heuristic=lambda d, s: heuristic(d, s),
+                time_budget=time_budget,
+                rollout_budget=rollout_budget,
+                max_depth=max_depth,
+                max_feasibility_trials=max_feasibility_trials,
+                graph_expansion_rate=graph_expansion_rate,
+                residual_moving_average_window=residual_moving_average_window,
+                epsilon=epsilon,
+                discount=discount,
+                action_choice_noise=action_choice_noise,
+                dead_end_cost=dead_end_cost,
+                online_node_garbage=online_node_garbage,
+                callback=callback,
+                verbose=verbose,
             )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/hub/solver/riw/riw.py
+++ b/skdecide/hub/solver/riw/riw.py
@@ -126,30 +126,38 @@ try:
             verbose (bool, optional): Boolean indicating whether verbose messages should be logged (True)
                 or not (False). Defaults to False.
             """
+            Solver.__init__(self, domain_factory=domain_factory)
             ParallelSolver.__init__(
                 self,
                 parallel=parallel,
                 shared_memory_proxy=shared_memory_proxy,
             )
-            Solver.__init__(self, domain_factory=domain_factory)
-            self._solver = None
-            self._domain = None
-            self._state_features = state_features
-            self._use_state_feature_hash = use_state_feature_hash
-            self._use_simulation_domain = use_simulation_domain
-            self._time_budget = time_budget
-            self._rollout_budget = rollout_budget
-            self._max_depth = max_depth
-            self._exploration = exploration
-            self._residual_moving_average_window = residual_moving_average_window
-            self._epsilon = epsilon
-            self._discount = discount
-            self._online_node_garbage = online_node_garbage
             self._continuous_planning = continuous_planning
-            self._callback = callback
-            self._verbose = verbose
-            self._lambdas = [self._state_features]
+            self._lambdas = [state_features]
             self._ipc_notify = True
+
+            self._solver = riw_solver(
+                solver=self,
+                domain=self.get_domain(),
+                state_features=(
+                    (lambda d, s, i=None: state_features(d, s))
+                    if not parallel
+                    else (lambda d, s, i=None: d.call(i, 0, s))
+                ),
+                use_state_feature_hash=use_state_feature_hash,
+                use_simulation_domain=use_simulation_domain,
+                time_budget=time_budget,
+                rollout_budget=rollout_budget,
+                max_depth=max_depth,
+                exploration=exploration,
+                residual_moving_average_window=residual_moving_average_window,
+                epsilon=epsilon,
+                discount=discount,
+                online_node_garbage=online_node_garbage,
+                parallel=parallel,
+                callback=callback,
+                verbose=verbose,
+            )
 
         def close(self):
             """Joins the parallel domains' processes.
@@ -162,31 +170,6 @@ try:
             if self._parallel:
                 self._solver.close()
             ParallelSolver.close(self)
-
-        def _init_solve(self) -> None:
-            self._solver = riw_solver(
-                solver=self,
-                domain=self.get_domain(),
-                state_features=(
-                    (lambda d, s, i=None: self._state_features(d, s))
-                    if not self._parallel
-                    else (lambda d, s, i=None: d.call(i, 0, s))
-                ),
-                use_state_feature_hash=self._use_state_feature_hash,
-                use_simulation_domain=self._use_simulation_domain,
-                time_budget=self._time_budget,
-                rollout_budget=self._rollout_budget,
-                max_depth=self._max_depth,
-                exploration=self._exploration,
-                residual_moving_average_window=self._residual_moving_average_window,
-                epsilon=self._epsilon,
-                discount=self._discount,
-                online_node_garbage=self._online_node_garbage,
-                parallel=self._parallel,
-                callback=self._callback,
-                verbose=self._verbose,
-            )
-            self._solver.clear()
 
         def _reset(self) -> None:
             """Clears the search graph."""

--- a/skdecide/solvers.py
+++ b/skdecide/solvers.py
@@ -152,9 +152,7 @@ class Solver(FromInitialState):
         pass
 
     def _initialize(self):
-        """Runs long-lasting initialization code here, or code to be executed at the
-        entering of a 'with' context statement.
-        """
+        """Runs long-lasting initialization code here."""
         pass
 
     def _cleanup(self):
@@ -169,7 +167,6 @@ class Solver(FromInitialState):
         clean their status before exiting the Python interpreter, thus it
         is a good habit to always call solvers within a 'with' statement.
         """
-        self._initialize()
         return self
 
     def __exit__(self, type, value, tb):


### PR DESCRIPTION
It would be more efficient to not reset c++ solvers between call to `solve() `as recalling previous searchs can be useful: `_init_solve()` should be called only once. Therefore we can put the related code directly in `__init__()` and remove `_init_solve()`.

Notes:
- on windows, c++ solvers need to be instantiated *after* the parallel domain. This is ensured by the call to `get_domain()` which in turns calls `_initialize()`.
- we must avoid calling twice `_initialize` to avoid having 2 sets of processes for parallel domain launched with the solver tracking only one set. Thus we need to stop calling _initialize in `__enter__` (as it is already called by get_domain when initializing c++ solver in `__init__()`)