### PR TITLE
Ensure compatibility with openap 2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -140,7 +140,7 @@ test = ["coveralls", "pytest (>=5.1.2)", "pytest-cov", "pytest-mpl (>=0.11)", "p
 name = "certifi"
 version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
@@ -213,7 +213,7 @@ pycparser = "*"
 name = "charset-normalizer"
 version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = false
+optional = true
 python-versions = ">=3.7.0"
 files = [
     {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
@@ -1230,7 +1230,7 @@ toy-text = ["pygame (==2.1.3)", "pygame (==2.1.3)"]
 name = "idna"
 version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
@@ -1455,7 +1455,7 @@ testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 name = "jinja2"
 version = "3.1.4"
 description = "A very fast and expressive template engine."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
@@ -1803,7 +1803,7 @@ testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 name = "markupsafe"
 version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc"},
@@ -3669,7 +3669,7 @@ rpds-py = ">=0.7.0"
 name = "requests"
 version = "2.32.2"
 description = "Python HTTP for Humans."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c"},
@@ -4414,7 +4414,7 @@ pytamer = "0.1.19"
 name = "urllib3"
 version = "2.2.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
@@ -4475,4 +4475,4 @@ solvers = ["discrete-optimization", "gymnasium", "joblib", "numpy", "ray", "stab
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "b0b4b47915d41f3cac59ca5a387d74236c941f8c9b2093bef3f005dd983bfd52"
+content-hash = "5a2099198e73e89c1abc9db6ff1f3ad6ef7dff34df66de5eb75d2308ee6423da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ pynng = ">=0.6.2"
 pathos = ">=0.2.7"
 scipy = { version = ">=1.9.2", optional = true }
 gymnasium = { version = ">=0.28.1", optional = true }
-numpy = { version = ">=1.20.1", optional = true }
+numpy = { version = "^1.20.1", optional = true }
 matplotlib = { version = ">=3.3.4", optional = true }
 joblib = { version = ">=1.0.1", optional = true }
 stable-baselines3 = { version = ">=2.0.0", optional = true }

--- a/skdecide/hub/domain/flight_planning/aircraft_performance/poll_schumann_utils/pollschumann.py
+++ b/skdecide/hub/domain/flight_planning/aircraft_performance/poll_schumann_utils/pollschumann.py
@@ -54,7 +54,7 @@ class FuelFlow:
         self,
         values_current: Dict[str, float],
         delta_time: float,
-        path_angle: Optional[float] = 0.0,
+        vs: Optional[float] = 0.0,
     ) -> float:
         """Compute fuel flow based on Poll-Schumann model.
 
@@ -63,8 +63,8 @@ class FuelFlow:
                 Dictionary with current values of altitude [:math:`ft`], speed [:math:`kts`], temperature [:math:`K`], and mass [:math:`Kg`].
             delta_time (float):
                 Time step in seconds [:math:`s`].
-            path_angle (Optional[float], optional):
-                Path angle. Defaults to 0.0 degrees.
+            vs (Optional[float], optional):
+                Vertical speed [:math: `ft/min`]. Defaults to 0.0 ft/min.
 
         # Returns
             float: Fuel flow, [:math:`Kg/s`].
@@ -77,9 +77,7 @@ class FuelFlow:
         mass_current = values_current["mass"]
 
         # values next
-        altitude_next = altitude_current + speed_current * delta_time * math.radians(
-            path_angle
-        )
+        altitude_next = altitude_current + vs * delta_time / 60  # s -> min
         # atmospheric quantities
         air_pressure = units.ft_to_pl(altitude_current) * 100.0
 

--- a/skdecide/hub/domain/flight_planning/domain.py
+++ b/skdecide/hub/domain/flight_planning/domain.py
@@ -883,10 +883,7 @@ class FlightPlanningDomain(
                 cost = self.perf_model.compute_fuel_consumption(
                     values_current,
                     delta_time=dt,
-                    path_angle=math.degrees(
-                        (alt_to - pos["alt"]) * ft / (distance_to_goal)
-                    ),
-                    # approximation for small angles: tan(alpha) ~ alpha
+                    vs=(alt_to - pos["alt"]) * 60 / dt,
                 )
             else:
                 cost = self.perf_model.compute_fuel_consumption(
@@ -1374,7 +1371,7 @@ class FlightPlanningDomain(
             pos["fuel"] = self.perf_model.compute_fuel_consumption(
                 values_current,
                 delta_time=dt,
-                path_angle=math.degrees((alt_to - pos["alt"]) * ft / (gs * dt)),
+                vs=(alt_to - pos["alt"]) * 60 / dt,  # ft/min
                 # approximation for small angles: tan(alpha) ~ alpha
             )
 


### PR DESCRIPTION
The fuel flow model has changed and `FuelFlow.enroute()` take `vs` (vertical
speed) as argument instead of `path_angle`.

So we adapt `AircraftPerformanceModel.compute_fuel_consumption()` to take
also `vs` as argument.
To be compatible with previous version, we make the conversion (`vs`->
`path_angle`) in case we still have path_angle in signature (openap
<=1.5).

Note that we needed to change expected values in `test_perf_model()`:
- for openap model, as they improves (and thus changed) the computation.
  We have 2 sets of value according to whether we are <2.0 or >=2.0
- for poll-schumann model as it was not correct before:

    `altitude_next = altitude_current + speed_current * delta_time * math.radians(path_angle)`

  should already have been

    `altitude_next = altitude_current + speed_current * delta_time * math.tan(math.radians(path_angle)) / ft`

  (with ft the constant to pass from feet to meters).

Now the test evaluates True both with openap 1.5 and 2.0.