### PR TITLE
Fix issues with ray-rllib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ numpy = { version = "^1.20.1", optional = true }
 matplotlib = { version = ">=3.3.4", optional = true }
 joblib = { version = ">=1.0.1", optional = true }
 stable-baselines3 = { version = ">=2.0.0", optional = true }
-ray = { extras = ["rllib"], version = ">=2.7.0", optional = true }
+ray = { extras = ["rllib"], version = ">=2.9.0", optional = true }
 discrete-optimization = {git = "https://github.com/airbus/discrete-optimization.git", branch = "master", optional = true }
 openap = { version = ">=1.5", python = ">=3.9", optional = true }
 pygeodesy = { version = ">=23.6.12", optional = true }

--- a/skdecide/hub/solver/ray_rllib/ray_rllib.py
+++ b/skdecide/hub/solver/ray_rllib/ray_rllib.py
@@ -452,7 +452,13 @@ class RayRLlib(Solver, Policies, Restorable):
                     callbacks_class=callbacks_class, config=self._algo.evaluation_config
                 )
             if self._algo.workers:
-                local_worker: RolloutWorker = self._algo.workers.local_worker()
+                if Version(ray.__version__) < Version("2.34.0"):
+                    # starting from 2.34, algo.workers becomes algo.env_runner_group
+                    local_worker: RolloutWorker = self._algo.workers.local_worker()
+                else:
+                    local_worker: RolloutWorker = (
+                        self._algo.env_runner_group.local_worker()
+                    )
                 if local_worker:
                     _set_callbackclass_in_config(
                         callbacks_class=callbacks_class, config=local_worker.config


### PR DESCRIPTION
- starting from 2.34, some renaming occurred, and the properties holding the previous names (e.g. Algorithm.workers) are not working because `Deprecated` decorator does not work well with python `@property`;
- we need ray>=2.9 so that import `from ray.rllib.algorithms import DQN, PPO, SAC` works, to be used in hyperparameter `algo_class` choices definition.