### PR TITLE
Correct bug when termination is None in new TerminationOutcome

### DIFF
--- a/skdecide/core.py
+++ b/skdecide/core.py
@@ -433,8 +433,8 @@ class TransitionOutcome(
             )
         if self.termination is None:
             self.termination = (
-                {k: False for k in self.observation}
-                if isinstance(self.observation, dict)
+                {k: False for k in self.state}
+                if isinstance(self.state, dict)
                 else False
             )
 


### PR DESCRIPTION
Creating a TerminationOutcome object with a termination equal to None raised an exception because self.observation is not defined by the TerminationOutcome class