### PR TITLE
Fix links to js code for deployed release doc

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -9,9 +9,14 @@ on:
         default: "doc"
         type: string
       doc-path:
-        description: "Path where to extract the built doc"
+        description: "Path where to find the built doc"
         required: false
         default: "docs/.vuepress/dist"
+        type: string
+      doc-version:
+        description: "version of the library for which we are building the doc. If empty, then it is main branch doc."
+        required: FALSE
+        default: ""
         type: string
       notebooks-repo-url:
         description: |
@@ -97,6 +102,18 @@ jobs:
           python_version=${{ env.python-version }}
           wheelfile=$(ls ./wheels/scikit_decide*-cp${python_version/\./}-*manylinux*.whl)
           pip install ${wheelfile}[all]
+      - name: set env.DOCS_VERSION_PATH aka subpath where the doc will be deployed
+        # DOCS_VERSION_PATH is used by yarn docs:build to preprend links to javascript with proper subpath
+        # See docs/.vuepress/config.js
+        id: set-doc-version-path
+        run: |
+          doc_version=${{ inputs.doc-version }}
+          if [ -z "${doc_version}" ]; then
+            doc_version_path="/"
+          else
+            doc_version_path="/version/${doc_version}/"
+          fi
+          echo "DOCS_VERSION_PATH=${doc_version_path}" >> $GITHUB_ENV
       - name: generate documentation
         run: |
           yarn global add vuepress && yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1016,7 +1016,7 @@ jobs:
           echo "binder_full_ref=${binder_full_ref}" >> $GITHUB_OUTPUT
 
   build-doc:
-    needs: [ build-ubuntu, setup, update-notebooks-for-colab-and-binder ]
+    needs: [ build-ubuntu, setup, update-notebooks-for-colab-and-binder, get-release-version ]
     # if: always()
     #  -> trigger even if one needed job was skipped (namely update-notebooks-for-colab-and-binder)
     #  -> needed jobs successes must be checked explicitely
@@ -1027,6 +1027,7 @@ jobs:
     uses: ./.github/workflows/build-doc.yml
     with:
       notebooks-branch: ${{ needs.update-notebooks-for-colab-and-binder.outputs.notebooks-branch }}
+      doc-version: ${{ needs.get-release-version.outputs.skdecide-version }}
 
   deploy:
     needs: [ trigger, test-ubuntu, test-macos, test-windows ]


### PR DESCRIPTION
In docs/.vuepress/config.js, the environment variable DOCS_VERSION_PATH is used to prepend the proper subpath to all javascript paths.

The generation of this variable was lost when build-doc.yml and deploy-doc sub-workflows were created to share the code beteween pr merge and release workflows. (A that moment, it was thought to be used only to deploy the doc at the correct path.)