### PR TITLE
Move minizinc installation instruction in "known issues"

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -24,12 +24,6 @@ This guide is organized as follows:
 
 ## Setting up your development environment
 
-### Prerequisite: minizinc  (optional)
-
-If you plan to use wrapped [discrete-optimization](https://github.com/airbus/discrete-optimization) solvers based on [minizinc](https://www.minizinc.org/),
-you need first to install minizinc binary (version greater than 2.8) and update the `PATH` environment variable
-so that it can be found by Python. See [minizinc documentation](https://www.minizinc.org/doc-latest/en/installation.html) for more details.
-
 ### Installing from source in developer mode
 
 > **Disclaimer**: The following process has only been tested on Linux/MacOS platforms.

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,75 @@
 
 ## Prerequisites
 
-### Minizinc 2.8+ (Optional)
+### Python 3.9+ environment
+
+The use of a virtual environment for scikit-decide is recommended, and you will need to ensure that the environment use a Python version greater than 3.9.
+This can be achieved either by using [conda](https://docs.conda.io/en/latest/) or by using [pyenv](https://github.com/pyenv/pyenv) (or [pyenv-win](https://github.com/pyenv-win/pyenv-win) on windows)
+and [venv](https://docs.python.org/fr/3/library/venv.html) module.
+
+The following examples show how to create a virtual environment with Python version 3.9.18 with the mentioned methods.
+
+#### With conda (all platforms)
+
+```shell
+conda create -n skdecide python=3.9.18
+conda activate skdecide
+```
+
+#### With pyenv + venv (Linux/MacOS)
+
+```shell
+pyenv install 3.9.18
+pyenv shell 3.9.18
+python -m venv skdecide-venv
+source skdecide-venv/bin/activate
+```
+
+#### With pyenv-win + venv (Windows)
+
+```shell
+pyenv install 3.9.18
+pyenv shell 3.9.18
+python -m venv skdecide-venv
+skdecide-venv\Scripts\activate
+```
+
+## Install scikit-decide library
+
+### Full install [Recommended]
+
+Install scikit-decide library from PyPI with all dependencies required by domains/solvers in the hub (scikit-decide catalog).
+```shell
+pip install -U pip
+pip install -U scikit-decide[all]
+```
+
+### Minimal install
+Alternatively you can choose to only install the core library, which is enough if you intend to create your own domain and solver.
+```shell
+pip install -U pip
+pip install -U scikit-decide
+```
+
+
+## Known issues
+
+### Pygrib
+
+When installing [pygrib](https://jswhit.github.io/pygrib/index.html) on MacOS ARM (in dependencies of `scikit-decide[all]`),
+no wheel exists on PyPI and there is issues when pip tries to build it.
+You can overcome this by first installing `eccodes` which provides GRIB header files required to build the `pygrib` wheel:
+```shell
+brew install eccodes
+```
+Then, reinstall `scikit-decide[all]` with pip.
+
+If the issue persists, you can try to install the pygrib package available on conda-forge:
+```shell
+conda install -c conda-forge pygrib
+```
+
+### Minizinc
 
 If you plan to use the solver for scheduling domains `DOSolver`
 that wraps [discrete-optimization](https://github.com/airbus/discrete-optimization) solvers,
@@ -59,73 +127,4 @@ curl -o minizinc_setup.exe -L https://github.com/MiniZinc/MiniZincIDE/releases/d
 cmd //c "minizinc_setup.exe /verysilent /currentuser /norestart /suppressmsgboxes /sp"
 export PATH="~/AppData/Local/Programs/MiniZinc":$PATH
 minizinc --version
-```
-
-
-### Python 3.9+ environment
-
-The use of a virtual environment for scikit-decide is recommended, and you will need to ensure that the environment use a Python version greater than 3.9.
-This can be achieved either by using [conda](https://docs.conda.io/en/latest/) or by using [pyenv](https://github.com/pyenv/pyenv) (or [pyenv-win](https://github.com/pyenv-win/pyenv-win) on windows)
-and [venv](https://docs.python.org/fr/3/library/venv.html) module.
-
-The following examples show how to create a virtual environment with Python version 3.9.18 with the mentioned methods.
-
-#### With conda (all platforms)
-
-```shell
-conda create -n skdecide python=3.9.18
-conda activate skdecide
-```
-
-#### With pyenv + venv (Linux/MacOS)
-
-```shell
-pyenv install 3.9.18
-pyenv shell 3.9.18
-python -m venv skdecide-venv
-source skdecide-venv/bin/activate
-```
-
-#### With pyenv-win + venv (Windows)
-
-```shell
-pyenv install 3.9.18
-pyenv shell 3.9.18
-python -m venv skdecide-venv
-skdecide-venv\Scripts\activate
-```
-
-## Install scikit-decide library
-
-### Full install [Recommended]
-
-Install scikit-decide library from PyPI with all dependencies required by domains/solvers in the hub (scikit-decide catalog).
-```shell
-pip install -U pip
-pip install -U scikit-decide[all]
-```
-
-### Minimal install
-Alternatively you can choose to only install the core library, which is enough if you intend to create your own domain and solver.
-```shell
-pip install -U pip
-pip install -U scikit-decide
-```
-
-
-## Known issues
-
-### pygrib
-
-When installing [pygrib](https://jswhit.github.io/pygrib/index.html) on MacOS ARM (in dependencies of `scikit-decide[all]`),
-no wheel exists on PyPI and there is issues when pip tries to build it.
-You can overcome this by first installing `eccodes` which provides GRIB header files required to build the `pygrib` wheel:
-```shell
-brew install eccodes
-```
-Then, reinstall `scikit-decide[all]` with pip.
-
-If the issue persists, you can try to install the pygrib package available on conda-forge:
-```shell
-conda install -c conda-forge pygrib
 ```


### PR DESCRIPTION
Minizinc is not mandatory anymore so should not be the first thing people see in installation instructions.
We let it in the known issues to ease its installation for people needing it.