### PR TITLE
Fix autodoc

### DIFF
--- a/docs/autodoc.py
+++ b/docs/autodoc.py
@@ -688,7 +688,8 @@ if __name__ == "__main__":
                             else:
                                 not_implemented.add(member_name)
                         elif member["type"] == "variable":
-                            types_dict[member_name] = member["ref"]
+                            if "ref" in member:
+                                types_dict[member_name] = member["ref"]
                     tmp_methods[level_name] = list(not_implemented)
                     tmp_types[level_name] = types_dict
             elif module["ref"] == f"skdecide.{element}s":


### PR DESCRIPTION
The new solver characteristic `Maskable` has a (hidden) attribute initialized to None. Thus the method  `get_ref()` does not work on it, and updating the types_dict for the code generator was failing. As this attribute is not used in type annotations of methods (which was the purpose of `types_dict`) this is not a real issue. So we merely skip adding a type to it when member["ref"] does not exist.