### PR TITLE
Update pyrddlgym-jax dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ pyRDDLGym-rl = [
     { version = ">=0.2", python = "<3.12", optional = true },
     { version = ">=0.1, <0.2", python = ">=3.12", optional = true },
 ]
-pyRDDLGym-jax = { version = ">=0.3", optional = true }
+pyRDDLGym-jax = { version = ">=1.1", optional = true }
 pyRDDLGym-gurobi = { version = ">=0.2", optional = true }
 rddlrepository = {version = ">=2.0", optional = true }
 torch-geometric = {version = ">=2.5", optional = true}


### PR DESCRIPTION
1.0 is not working with python 3.9