### PR TITLE
Freeze temporarily the version of cache-apt-pkgs-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,7 +709,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install needed apt dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           packages: libeccodes-dev
 


### PR DESCRIPTION
The "latest" tag does not correspond anymore to the latest version, and thus we used an older version which rely on actions/upload-artifact@v3 which now makes job crash.

See https://github.com/awalsh128/cache-apt-pkgs-action/issues/145 and https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/