### PR TITLE
Stop testing weather interpolation and fix $\{delta}ISA$ to 0.0

### DIFF
--- a/skdecide/hub/domain/flight_planning/domain.py
+++ b/skdecide/hub/domain/flight_planning/domain.py
@@ -1834,8 +1834,9 @@ class FlightPlanningDomain(
                     [pos["ts"], (pos["alt"] + alt_to) / 2, pos["lat"], pos["lon"]],
                     field="temperature",
                 )
-
                 dISA = temp - temperature((pos["alt"] + alt_to) / 2, disa=0)
+            else:
+                dISA = 0.0
 
             isa_atmosphere_settings = IsaAtmosphereSettings(d_isa=dISA)
 

--- a/tests/flight_planning/test_flight_planning.py
+++ b/tests/flight_planning/test_flight_planning.py
@@ -113,15 +113,12 @@ def test_flight_planning():
         gamma_air_deg=0,
     )
 
-    weather_date = WeatherDate(day=1, month=12, year=2024)
-
     domain_factory = lambda: FlightPlanningDomain(
         origin="LFBO",
         destination="LFPG",
         aircraft_state=acState_poll_schumann,
         objective="fuel",
         heuristic_name="lazy_fuel",
-        weather_date=weather_date,
         cruise_height_min=32_000,
         cruise_height_max=38_000,
         graph_width="medium",


### PR DESCRIPTION
The webservice used to download weather is  not completely reliable and makes the tests fail more and more often. So we stop trying to download those data.

When not relying on weather_interpolator, dISA was not defined so we set it to 0., assuming standard atmosphere.