### PR TITLE
Revert "Freeze temporarily the version of cache-apt-pkgs-action"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,7 +709,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install needed apt dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libeccodes-dev
 


### PR DESCRIPTION
This reverts commit 4701c12a85f8fc82ab0c9086642c6ef0dac714fa.

The issue with cache-apt-pkgs-action has been solved: https://github.com/awalsh128/cache-apt-pkgs-action/issues/145#issuecomment-2611515252