### PR TITLE
Fix msvc 19.43.34808.0 compilation errors and warnings

### DIFF
--- a/cpp/src/hub/solver/aostar/aostar.hh
+++ b/cpp/src/hub/solver/aostar/aostar.hh
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include <list>
 #include <queue>
+#include <chrono>
 
 #include "utils/associative_container_deducer.hh"
 #include "utils/execution.hh"

--- a/cpp/src/hub/solver/mcts/mcts.hh
+++ b/cpp/src/hub/solver/mcts/mcts.hh
@@ -615,9 +615,6 @@ private:
                        std::unordered_set<StateNode *> &child_subgraph);
   void update_residual_moving_average(const StateNode &node,
                                       const double &node_record_value);
-  std::size_t
-  elapsed_time(const std::chrono::time_point<std::chrono::high_resolution_clock>
-                   &start_time);
 }; // MCTSSolver class
 
 /** UCT as described in the paper " Bandit Based Monte-Carlo Planning" by


### PR DESCRIPTION
This PR:
- removes MSVC compilation errors C2039, C2065, C2923, C2976 and C2955 due to missing `chrono` header include in `aostar.hh` ;
- removes MSVC compilation warning C4661 due to non implemented `MCTS::elaped_time()` method which is indeed no more used in the code.