### PR TITLE
Monkey patch directly rllib concat_samples() function

### DIFF
--- a/skdecide/hub/solver/ray_rllib/gnn/policy/sample_batch_monkey_patch.py
+++ b/skdecide/hub/solver/ray_rllib/gnn/policy/sample_batch_monkey_patch.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from ray.rllib.policy.sample_batch import concat_samples
+
+from skdecide.hub.solver.ray_rllib.gnn.policy.sample_batch import (
+    concat_samples_graph,
+    concat_samples_graph2node,
+)
+from skdecide.hub.solver.ray_rllib.gnn.policy.sample_batch_original_code import (
+    original_concat_samples,
+)
+
+
+def monkey_patch_concat_samples(graph2node: bool = False) -> None:
+    """Monkey patch rllib so that concat_samples pad graph arrays if necessary.
+
+    Note we need to update functions
+    - `__code__`:  bytecode
+    - `__globals__`: namespace, immutable attribute, which is actually
+       the namespace of the functions modules
+
+    That's why
+    - we put `original_concat_samples` in a dedicated module so that its namespace can be updated by
+      concat_samples.__globals__ without side effects
+    - we only add to concat_samples.__globals__ the necessary names
+      ("original_concat_samples" and "prepare_for_concat_samples_graph2node" or "prepare_for_concat_samples_graph")
+      as it is skdecide.hub.solver.ray_rllib.gnn.policy.sample_batch namespace.
+
+    """
+    if not hasattr(original_concat_samples, "_original_globals"):
+        # store original function code only if not already done
+        original_concat_samples.__code__ = concat_samples.__code__
+        original_concat_samples._original_globals = dict(concat_samples.__globals__)
+        original_concat_samples.__globals__.update(concat_samples.__globals__)
+
+    if graph2node:
+        new_concat_samples = concat_samples_graph2node
+    else:
+        new_concat_samples = concat_samples_graph
+    concat_samples.__code__ = new_concat_samples.__code__
+    for name in concat_samples.__code__.co_names:
+        concat_samples.__globals__[name] = new_concat_samples.__globals__[name]
+
+
+def unmonkey_patch_concat_samples() -> None:
+    if hasattr(original_concat_samples, "_original_globals"):
+        concat_samples.__code__ = original_concat_samples.__code__
+        for k in list(concat_samples.__globals__):
+            concat_samples.__globals__.pop(k)
+        concat_samples.__globals__.update(original_concat_samples._original_globals)
+        del original_concat_samples._original_globals

--- a/skdecide/hub/solver/ray_rllib/gnn/policy/sample_batch_original_code.py
+++ b/skdecide/hub/solver/ray_rllib/gnn/policy/sample_batch_original_code.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from ray.rllib.utils.typing import SampleBatchType
+
+
+def original_concat_samples(samples: list[SampleBatchType]) -> SampleBatchType:
+    """Function placeholder to be used to store the original concat_samples code"""
+    ...

--- a/skdecide/hub/solver/ray_rllib/gnn/utils/monkey_patch.py
+++ b/skdecide/hub/solver/ray_rllib/gnn/utils/monkey_patch.py
@@ -2,17 +2,17 @@ from skdecide.hub.solver.ray_rllib.gnn.evaluation.collectors.agent_collector imp
     monkey_patch_agent_collector,
     unmonkey_patch_agent_collector,
 )
-from skdecide.hub.solver.ray_rllib.gnn.evaluation.collectors.simple_list_collector import (
-    monkey_patch_policy_collector,
-    unmonkey_patch_policy_collector,
+from skdecide.hub.solver.ray_rllib.gnn.policy.sample_batch_monkey_patch import (
+    monkey_patch_concat_samples,
+    unmonkey_patch_concat_samples,
 )
 
 
 def monkey_patch_rllib_for_graph(graph2node: bool = False):
     monkey_patch_agent_collector(graph2node=graph2node)
-    monkey_patch_policy_collector(graph2node=graph2node)
+    monkey_patch_concat_samples(graph2node=graph2node)
 
 
 def unmonkey_patch_rllib_for_graph():
     unmonkey_patch_agent_collector()
-    unmonkey_patch_policy_collector()
+    unmonkey_patch_concat_samples()

--- a/tests/solvers/python/test_gnn_ray_rllib.py
+++ b/tests/solvers/python/test_gnn_ray_rllib.py
@@ -16,8 +16,8 @@ def ray_init():
     # add module test_gnn_ray_rllib and thus GraphMaze to ray runtimeenv
     ray.init(
         ignore_reinit_error=True,
-        # runtime_env={"working_dir": os.path.dirname(__file__)},
-        local_mode=True,  # uncomment this line and comment the one above to debug more easily
+        runtime_env={"working_dir": os.path.dirname(__file__)},
+        # local_mode=True,  # uncomment this line and comment the one above to debug more easily
     )
 
 


### PR DESCRIPTION
During training of gnn's with rllib, concat_samples was actually called several times with samples of graphs with potentially different structure. So it is "easier" to directly monkey patch it (even though monkey patching a function is a bit more tedious than patching a method).