### PR TITLE
Implement autoregressive sb3 PPO with graph observations 

### DIFF
--- a/examples/pddl/blocksworld-graph-objects.py
+++ b/examples/pddl/blocksworld-graph-objects.py
@@ -1,0 +1,81 @@
+"""Blocksworld with 3 objects with graph-objects representation + sb3 autoregressive solver.
+
+Blocksworld: https://en.wikipedia.org/wiki/Blocks_world
+Graph-objects representation = Objects Binary Structure presented in
+    Horčík, R., & Šír, G. (2024). Expressiveness of Graph Neural Networks in Planning Domains.
+    Proceedings of the International Conference on Automated Planning and Scheduling, 34(1), 281-289.
+    https://ojs.aaai.org/index.php/ICAPS/article/view/31486
+sb3-autoregressive: components of the action are predicted one by one,
+    taking into account the choices of the previous components.
+
+"""
+
+
+import os
+
+from skdecide import rollout
+from skdecide.hub.domain.plado import (
+    ActionEncoding,
+    ObservationEncoding,
+    PladoTransformedObservablePddlDomain,
+)
+from skdecide.hub.solver.stable_baselines import StableBaseline
+from skdecide.hub.solver.stable_baselines.autoregressive.ppo.autoregressive_ppo import (
+    AutoregressiveGraphPPO,
+)
+
+pddl_examples_dir = os.path.dirname(os.path.abspath(__file__))
+pddl_domains_def_dir = os.path.abspath(
+    f"{pddl_examples_dir}/../../tests/domains/python/pddl_domains"
+)
+
+domain_path = f"{pddl_domains_def_dir}/blocks/domain.pddl"
+problem_path = f"{pddl_domains_def_dir}/blocks/probBLOCKS-3-0.pddl"
+
+domain_factory = lambda: PladoTransformedObservablePddlDomain(
+    domain_path=domain_path,
+    problem_path=problem_path,
+    obs_encoding=ObservationEncoding.GYM_GRAPH_OBJECTS,
+    action_encoding=ActionEncoding.GYM_MULTIDISCRETE,
+)
+
+# Feature extraction via GNN
+with StableBaseline(
+    domain_factory=domain_factory,
+    algo_class=AutoregressiveGraphPPO,
+    baselines_policy="GraphInputPolicy",
+    autoregressive_action=True,
+    learn_config={"total_timesteps": 10_000},
+    verbose=1,
+) as solver:
+    solver.solve()
+    max_steps = 50
+    episodes = rollout(
+        domain=domain_factory(),
+        solver=solver,
+        max_steps=max_steps,
+        num_episodes=1,
+        render=False,
+        return_episodes=True,
+    )
+
+
+# + node prediction via GNN for actions parameters
+with StableBaseline(
+    domain_factory=domain_factory,
+    algo_class=AutoregressiveGraphPPO,
+    baselines_policy="Graph2NodePolicy",
+    autoregressive_action=True,
+    learn_config={"total_timesteps": 10_000},
+    verbose=1,
+) as solver:
+    solver.solve()
+    max_steps = 50
+    episodes = rollout(
+        domain=domain_factory(),
+        solver=solver,
+        max_steps=max_steps,
+        num_episodes=1,
+        render=False,
+        return_episodes=True,
+    )

--- a/skdecide/hub/domain/plado/__init__.py
+++ b/skdecide/hub/domain/plado/__init__.py
@@ -1,1 +1,9 @@
-from .plado import ActionEncoding, PladoPddlDomain, PladoPPddlDomain, StateEncoding
+from .plado import (
+    ActionEncoding,
+    ObservationEncoding,
+    PladoPddlDomain,
+    PladoPPddlDomain,
+    PladoTransformedObservablePddlDomain,
+    PladoTransformedObservablePPddlDomain,
+    StateEncoding,
+)

--- a/skdecide/hub/solver/stable_baselines/autoregressive/common/buffers.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/common/buffers.py
@@ -8,6 +8,7 @@ from skdecide.hub.solver.stable_baselines.common.buffers import (
     MaskableScikitDecideRolloutBufferMixin,
     ScikitDecideRolloutBuffer,
 )
+from skdecide.hub.solver.stable_baselines.gnn.common.buffers import GraphRolloutBuffer
 
 
 class ApplicableActionsRolloutBuffer(
@@ -46,3 +47,15 @@ class ApplicableActionsRolloutBuffer(
 
     def _get_action_masks_samples(self, batch_inds: np.ndarray) -> list[th.Tensor]:
         return [self.to_torch(self.action_masks[idx]) for idx in batch_inds]
+
+
+class ApplicableActionsGraphRolloutBuffer(
+    GraphRolloutBuffer, ApplicableActionsRolloutBuffer
+):
+    """Buffer to store graph obs + applicable actions.
+
+    Both have variable shape thus need a dedicated buffer that will not initialize the buffer with fixed shapes.
+
+    """
+
+    ...

--- a/skdecide/hub/solver/stable_baselines/autoregressive/common/distributions.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/common/distributions.py
@@ -72,6 +72,16 @@ class MultiMaskableCategoricalDistribution(Distribution):
     def set_proba_distribution_component(
         self, i_component: int, action_component_logits: th.Tensor
     ) -> None:
+        """Fix parameters of the marginal distribution.
+
+        We allow to modify dynamically the marginal dimension by inferring it from
+        last dimension of `action_component_logits`.
+        This is useful when the dimension of the marginal can change during rollout
+        (e.g. when this predict node id's of a graph whose structure vary)
+
+        """
+        action_component_dim = action_component_logits.shape[-1]
+        self.distributions[i_component].action_dim = action_component_dim
         self.distributions[i_component].proba_distribution(
             action_logits=action_component_logits
         )

--- a/skdecide/hub/solver/stable_baselines/autoregressive/common/on_policy_algorithm.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/common/on_policy_algorithm.py
@@ -1,0 +1,72 @@
+from typing import Optional, Union
+
+import numpy as np
+import torch as th
+from gymnasium import spaces
+from sb3_contrib.common.maskable.buffers import (
+    MaskableDictRolloutBuffer,
+    MaskableRolloutBuffer,
+)
+from sb3_contrib.common.maskable.utils import get_action_masks, is_masking_supported
+from stable_baselines3.common.buffers import RolloutBuffer
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.on_policy_algorithm import OnPolicyAlgorithm
+from stable_baselines3.common.policies import ActorCriticPolicy
+from stable_baselines3.common.type_aliases import GymEnv, TensorDict
+from stable_baselines3.common.vec_env import VecEnv
+
+from ...common.on_policy_algorithm import SkdecideOnPolicyAlgorithm
+from ...gnn.common.utils import obs_as_tensor
+from ...gnn.common.vec_env.dummy_vec_env import wrap_graph_env
+from .buffers import ApplicableActionsGraphRolloutBuffer, ApplicableActionsRolloutBuffer
+
+
+class ApplicableActionsOnPolicyAlgorithm(SkdecideOnPolicyAlgorithm):
+    """Base class for On-Policy algorithms (ex: A2C/PPO) using list of applicable actions."""
+
+    support_action_masking = True
+
+    def __init__(
+        self,
+        policy: Union[str, type[ActorCriticPolicy]],
+        env: GymEnv,
+        rollout_buffer_class: Optional[type[RolloutBuffer]] = None,
+        **kwargs,
+    ):
+
+        # Use proper default rollout buffer class
+        if rollout_buffer_class is None:
+            if isinstance(env.observation_space, spaces.Graph):
+                rollout_buffer_class = ApplicableActionsGraphRolloutBuffer
+            else:
+                rollout_buffer_class = ApplicableActionsRolloutBuffer
+
+        # Check only using dummy VecEnv
+        if isinstance(env, VecEnv) and env.num_envs > 1:
+            raise NotImplementedError(
+                "ApplicableActionsOnPolicyAlgorithm not implemented for real vectorized environment "
+                "(ie. with more than 1 wrapped environment)"
+            )
+
+        super().__init__(
+            policy=policy,
+            env=env,
+            rollout_buffer_class=rollout_buffer_class,
+            **kwargs,
+        )
+
+
+class ApplicableActionsGraphOnPolicyAlgorithm(ApplicableActionsOnPolicyAlgorithm):
+    """Base class for On-Policy algorithms (ex: A2C/PPO) using list of applicable actions and graph obs."""
+
+    @staticmethod
+    def _wrap_env(
+        env: GymEnv, verbose: int = 0, monitor_wrapper: bool = True
+    ) -> VecEnv:
+        return wrap_graph_env(env, verbose=verbose, monitor_wrapper=monitor_wrapper)
+
+    @staticmethod
+    def obs_as_tensor(
+        obs: Union[np.ndarray, dict[str, np.ndarray]], device: th.device
+    ) -> Union[th.Tensor, TensorDict]:
+        return obs_as_tensor(obs=obs, device=device)

--- a/skdecide/hub/solver/stable_baselines/autoregressive/ppo/autoregressive_ppo.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/ppo/autoregressive_ppo.py
@@ -1,26 +1,27 @@
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from sb3_contrib import MaskablePPO
-from stable_baselines3.common.buffers import RolloutBuffer
-from stable_baselines3.common.policies import ActorCriticPolicy, BasePolicy
-from stable_baselines3.common.type_aliases import GymEnv
+from stable_baselines3.common.policies import BasePolicy
 
-from skdecide.hub.solver.stable_baselines.autoregressive.common.buffers import (
-    ApplicableActionsRolloutBuffer,
+from skdecide.hub.solver.stable_baselines.autoregressive.common.on_policy_algorithm import (
+    ApplicableActionsGraphOnPolicyAlgorithm,
+    ApplicableActionsOnPolicyAlgorithm,
 )
 from skdecide.hub.solver.stable_baselines.autoregressive.common.policies import (
     AutoregressiveActorCriticPolicy,
+    AutoregressiveGNNActorCriticPolicy,
+    AutoregressiveGraph2NodeActorCriticPolicy,
 )
 
 
-class AutoregressivePPO(MaskablePPO):
+class AutoregressivePPO(ApplicableActionsOnPolicyAlgorithm, MaskablePPO):
     """Proximal Policy Optimization algorithm (PPO) with autoregressive action prediction.
 
     The action is multidiscrete and each component is predicted by using the observation + the previous components
     (already predicted). A -1 in the components is valid and interpreted as "no component" and we assume that no further
     components have a meaning for this particular action (correspond to actions with a variable number of parameters).
 
-    See the policy `AutoregressiveRestrictedMultiDiscreteActorCriticPolicy` for more details.
+    See the policy `AutoregressiveActorCriticPolicy` for more details.
 
     """
 
@@ -28,21 +29,26 @@ class AutoregressivePPO(MaskablePPO):
         "MlpPolicy": AutoregressiveActorCriticPolicy,
     }
 
-    def __init__(
-        self,
-        policy: Union[str, type[ActorCriticPolicy]],
-        env: GymEnv,
-        rollout_buffer_class: Optional[type[RolloutBuffer]] = None,
-        **kwargs,
-    ):
 
-        # Use proper default rollout buffer class
-        if rollout_buffer_class is None:
-            rollout_buffer_class = ApplicableActionsRolloutBuffer
+class AutoregressiveGraphPPO(
+    ApplicableActionsGraphOnPolicyAlgorithm, AutoregressivePPO
+):
+    """Proximal Policy Optimization algorithm (PPO) with autoregressive action prediction and graph observation.
 
-        super().__init__(
-            policy=policy,
-            env=env,
-            rollout_buffer_class=rollout_buffer_class,
-            **kwargs,
-        )
+    As for AutoregressivePPO, components are predicted via neural networks applied to
+    observations + previous components.
+
+    Two default policies that derive from `AutoregressiveActorCriticPolicy`:
+        - "GraphInputPolicy":  With no more hypotheses on actions structure, we simply use a GNN for feature extraction.
+          See `skdecide.hub.solver.utils.gnn.torch_layers.GraphFeaturesExtractor` for more details.
+        - "Graph2NodePolicy": We suppose that some action components are actually nodes of the observation graph.
+            (given by a policy arg `graph2node_components` as alist of booleans). So we apply
+            `skdecide.hub.solver.utils.gnn.torch_layers.Graph2NodeLayer` to predict these components.
+            By default we assume that the first component is not a graph node but the others are.
+
+    """
+
+    policy_aliases: ClassVar[dict[str, type[BasePolicy]]] = {
+        "GraphInputPolicy": AutoregressiveGNNActorCriticPolicy,
+        "Graph2NodePolicy": AutoregressiveGraph2NodeActorCriticPolicy,
+    }

--- a/skdecide/hub/solver/stable_baselines/gnn/common/policies.py
+++ b/skdecide/hub/solver/stable_baselines/gnn/common/policies.py
@@ -34,6 +34,8 @@ from .utils import ObsType, TorchObsType, is_vectorized_observation, obs_as_tens
 
 
 class BaseGNNPolicy(BasePolicy):
+    observation_space: spaces.Graph
+
     def extract_features(
         self, obs: thg.data.Data, features_extractor: BaseFeaturesExtractor
     ) -> th.Tensor:

--- a/skdecide/hub/solver/stable_baselines/gnn/common/preprocessing.py
+++ b/skdecide/hub/solver/stable_baselines/gnn/common/preprocessing.py
@@ -52,7 +52,12 @@ def get_obs_shape(
     """
     if isinstance(observation_space, spaces.Graph):
         # Will not be used
-        return observation_space.node_space.shape + observation_space.edge_space.shape
+        if observation_space.edge_space is None:
+            return observation_space.node_space.shape
+        else:
+            return (
+                observation_space.node_space.shape + observation_space.edge_space.shape
+            )
     elif isinstance(observation_space, spaces.Dict):
         return {key: get_obs_shape(subspace) for (key, subspace) in observation_space.spaces.items()}  # type: ignore[misc]
     else:

--- a/skdecide/hub/solver/stable_baselines/gnn/common/utils.py
+++ b/skdecide/hub/solver/stable_baselines/gnn/common/utils.py
@@ -15,9 +15,13 @@ TorchObsType = Union[TorchSubObsType, dict[str, TorchSubObsType]]
 
 
 def copy_graph_instance(g: gym.spaces.GraphInstance) -> gym.spaces.GraphInstance:
-    return gym.spaces.GraphInstance(
-        nodes=np.copy(g.nodes), edges=np.copy(g.edges), edge_links=np.copy(g.edge_links)
-    )
+    nodes = np.copy(g.nodes)
+    edge_links = np.copy(g.edge_links)
+    if g.edges is None:
+        edges = None
+    else:
+        edges = np.copy(g.edges)
+    return gym.spaces.GraphInstance(nodes=nodes, edges=edges, edge_links=edge_links)
 
 
 def copy_np_array_or_list_of_graph_instances(

--- a/skdecide/hub/solver/utils/gnn/space_utils.py
+++ b/skdecide/hub/solver/utils/gnn/space_utils.py
@@ -1,0 +1,26 @@
+import gymnasium as gym
+import numpy as np
+
+
+def add_onehot_encoded_discrete_feature_to_graph_space(
+    graph_space: gym.spaces.Graph, new_dim: int
+) -> gym.spaces.Graph:
+    node_space = graph_space.node_space
+    if isinstance(node_space, gym.spaces.Box):
+        node_space = add_onehot_encoded_discrete_feature_to_box_space(
+            node_space, new_dim
+        )
+    else:
+        raise NotImplementedError()
+    return gym.spaces.Graph(
+        node_space=node_space,
+        edge_space=graph_space.edge_space,
+    )
+
+
+def add_onehot_encoded_discrete_feature_to_box_space(
+    box_space: gym.spaces.Box, new_dim: int
+) -> gym.spaces.Box:
+    low = np.concatenate((box_space.low.flatten(), np.array([0] * new_dim)))
+    high = np.concatenate((box_space.high.flatten(), np.array([1] * new_dim)))
+    return gym.spaces.Box(low=low, high=high, dtype=box_space.dtype)

--- a/skdecide/hub/solver/utils/gnn/torch_layers.py
+++ b/skdecide/hub/solver/utils/gnn/torch_layers.py
@@ -92,7 +92,10 @@ class GraphFeaturesExtractor(nn.Module):
             observations.batch,
         )
         # construct edge weights, for GNNs needing it, as the first edge feature
-        edge_weight = edge_attr[:, 0]
+        if edge_attr is not None and len(edge_attr.shape) > 1:
+            edge_weight = edge_attr[:, 0]
+        else:
+            edge_weight = None
         h = self.gnn(
             x=x, edge_index=edge_index, edge_weight=edge_weight, edge_attr=edge_attr
         )
@@ -177,7 +180,10 @@ class Graph2NodeLayer(nn.Module):
             observations.batch,
         )
         # construct edge weights, for GNNs needing it, as the first edge feature
-        edge_weight = edge_attr[:, 0]
+        if edge_attr is not None and len(edge_attr.shape) > 1:
+            edge_weight = edge_attr[:, 0]
+        else:
+            edge_weight = None
         h = self.gnn(
             x=x, edge_index=edge_index, edge_weight=edge_weight, edge_attr=edge_attr
         )

--- a/tests/solvers/python/autoregressive/test_autoregressive_sb3.py
+++ b/tests/solvers/python/autoregressive/test_autoregressive_sb3.py
@@ -4,6 +4,7 @@ from skdecide.hub.solver.stable_baselines.autoregressive.common.buffers import (
     ApplicableActionsRolloutBuffer,
 )
 from skdecide.hub.solver.stable_baselines.autoregressive.ppo.autoregressive_ppo import (
+    AutoregressiveGraphPPO,
     AutoregressivePPO,
 )
 
@@ -41,6 +42,116 @@ def test_autoregressive_ppo_w_skdecide_domain(graph_walk_domain_factory):
         domain_factory=domain_factory,
         algo_class=AutoregressivePPO,
         baselines_policy="MlpPolicy",
+        autoregressive_action=True,
+        learn_config={"total_timesteps": 300},
+        n_steps=100,
+    ) as solver:
+        solver.solve()
+        max_steps = 20
+        episodes = rollout(
+            domain=domain_factory(),
+            solver=solver,
+            max_steps=max_steps,
+            num_episodes=1,
+            render=False,
+            return_episodes=True,
+        )
+        observations, actions, values = episodes[0]
+        assert (
+            len(actions) < max_steps - 1
+        )  # optimal would be 2, but not always found...
+
+
+def test_autoregressive_graph_ppo_w_gym_env(graph_walk_with_graph_obs_env):
+    env = graph_walk_with_graph_obs_env
+
+    algo = AutoregressiveGraphPPO(
+        "GraphInputPolicy",
+        env,
+        n_steps=100,
+    )
+    algo.learn(total_timesteps=500)
+
+    # rollout
+    obs, info = env.reset()
+    terminal = False
+    i_step = 0
+    print(f"#{i_step}: obs={obs}, terminal={terminal}")
+
+    max_steps = 20
+
+    while i_step < max_steps and not terminal:
+        i_step += 1
+        action, _ = algo.predict(obs, action_masks=env.action_masks())
+        obs, reward, terminal, truncated, info = env.step(action)
+        print(f"#{i_step}: action={action}, obs={obs}, terminal={terminal}")
+
+    assert i_step < max_steps  # optimal would be 2, but not always found...
+
+
+def test_autoregressive_graph_ppo_w_skdecide_domain(
+    graph_walk_with_graph_obs_domain_factory,
+):
+    domain_factory = graph_walk_with_graph_obs_domain_factory
+    with StableBaseline(
+        domain_factory=domain_factory,
+        algo_class=AutoregressiveGraphPPO,
+        baselines_policy="GraphInputPolicy",
+        autoregressive_action=True,
+        learn_config={"total_timesteps": 300},
+        n_steps=100,
+    ) as solver:
+        solver.solve()
+        max_steps = 20
+        episodes = rollout(
+            domain=domain_factory(),
+            solver=solver,
+            max_steps=max_steps,
+            num_episodes=1,
+            render=False,
+            return_episodes=True,
+        )
+        observations, actions, values = episodes[0]
+        assert (
+            len(actions) < max_steps - 1
+        )  # optimal would be 2, but not always found...
+
+
+def test_autoregressive_graph2node_ppo_w_gym_env(graph_walk_with_graph_obs_env):
+    env = graph_walk_with_graph_obs_env
+
+    algo = AutoregressiveGraphPPO(
+        "Graph2NodePolicy",
+        env,
+        n_steps=100,
+    )
+    algo.learn(total_timesteps=500)
+
+    # rollout
+    obs, info = env.reset()
+    terminal = False
+    i_step = 0
+    print(f"#{i_step}: obs={obs}, terminal={terminal}")
+
+    max_steps = 20
+
+    while i_step < max_steps and not terminal:
+        i_step += 1
+        action, _ = algo.predict(obs, action_masks=env.action_masks())
+        obs, reward, terminal, truncated, info = env.step(action)
+        print(f"#{i_step}: action={action}, obs={obs}, terminal={terminal}")
+
+    assert i_step < max_steps  # optimal would be 2, but not always found...
+
+
+def test_autoregressive_graph2node_ppo_w_skdecide_domain(
+    graph_walk_with_graph_obs_domain_factory,
+):
+    domain_factory = graph_walk_with_graph_obs_domain_factory
+    with StableBaseline(
+        domain_factory=domain_factory,
+        algo_class=AutoregressiveGraphPPO,
+        baselines_policy="Graph2NodePolicy",
         autoregressive_action=True,
         learn_config={"total_timesteps": 300},
         n_steps=100,


### PR DESCRIPTION
Autoregressive prediction as before and
- option 1: only features extraction via GNN
- option 2: we know that some components are observation graph nodes => we use `Graph2NodeLayer` for these components, ie GNN to directly predict action component logits from observation enriched with previous action components endoded as additional graph node features:
  - graph-independent components are one-hot encoded and added to all nodes (emulating a global feature that must be seen as a node feature by off-the-shelf GNN models from pytorch_geometric)
  - graph node components are encoded by their position among the graph node components. 
    For instance, we have actions represented by an action type (among 3) and 3 parameters being nodes, and we want to predict the last component knowing the first ones being (1,2,1), ie action_id=1 and parameters node 2, node 1, the corresponding encoding will be:
     - for node 0: (0,1,0) + (0,0,0) -> onehot encoding of  action_id=1 + not yet chosen among parameters
     - for node 1: (0,1,0) + (0,1,0)  -> onehot encoding of  action_id=1 + chosen in second position
     - for node 2: (0,1,0) + (1,0,0)  -> onehot encoding of  action_id=1 + chosen in first position 

In that way, the dimension of the features is independent of the number of nodes in the graph which is required to be applied to any graph structure (potentially changing between observations) but rather related to the dimension of components independent to the graph + the (max) number of action parameters which are graph nodes.

We test it on PDDL domain with graph-objects representation ie the  "Object Binary Structure" from
    Horčík, R., & Šír, G. (2024). Expressiveness of Graph Neural Networks in Planning Domains.
    Proceedings of the International Conference on Automated Planning and Scheduling, 34(1), 281-289.
    https://ojs.aaai.org/index.php/ICAPS/article/view/31486