### PR TITLE
Install cmake<4 in github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
+
       - name: Load cached venv
         id: cached-pip-wheels
         uses: actions/cache@v4
@@ -261,6 +266,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
 
       - name: Load cached venv
         id: cached-pip-wheels
@@ -409,6 +419,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.6'
 
       - name: Load cached venv
         id: cached-pip-wheels


### PR DESCRIPTION
Some github runners embed now a cmake>=4.0 which is not yet compatible with the cmake files. So we freeze it to the previous version (3.31.6) thanks to a dedicated github action.

See the issue and the workaround here: https://github.com/actions/runner-images/issues/11926#issuecomment-2779500114