### PR TITLE
Implement a custom GNN class

### DIFF
--- a/skdecide/hub/solver/utils/gnn/advanced_gnn.py
+++ b/skdecide/hub/solver/utils/gnn/advanced_gnn.py
@@ -1,0 +1,182 @@
+from collections.abc import Callable
+from typing import Any, Optional, Union
+
+from torch import Tensor, nn
+from torch_geometric.nn import MessagePassing
+from torch_geometric.nn.resolver import activation_resolver
+from torch_geometric.typing import Adj, OptTensor
+
+
+class AdvancedGNN(nn.Module):
+    """Customized GNN based on torch_geometric BasicGNN
+
+    It adds the possibility:
+    - to repeat the same layer instead of duplicate it (only 1 set of parameters to learn)
+    - to start with a (linear) encoding layer
+    - to end with  a (linear) decoding layer
+
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        num_layers: int,
+        message_passing_cls: type[MessagePassing],
+        supports_edge_weight: bool = False,
+        supports_edge_attr: bool = False,
+        out_channels: Optional[int] = None,
+        dropout: float = 0.0,
+        repeat_hidden_layer: bool = True,
+        using_encoder: bool = True,
+        using_decoder: bool = True,
+        act: Union[str, Callable, None] = "relu",
+        act_kwargs: Optional[dict[str, Any]] = None,
+        **kwargs,
+    ):
+        """
+
+        Args:
+            in_channels: input dim
+            hidden_channels: dim of hidden layers
+            num_layers: number of hidden layers
+            message_passing_cls: MessagePassing subclass used to init each layer
+            supports_edge_weight: supports message passing with one-dimensional edge weight
+            supports_edge_attr: supports message passing with multi-dimensional edge feature
+            out_channels: dim of output layer. If None, no output layer is added
+            dropout: dropout probability (use after each layer, except for the output layer)
+            repeat_hidden_layer: whether to pass repeatedly (if True) through the same hidden layer
+                or to create several layers
+            using_encoder: if True the first input layer is a classical MLP on node features,
+                else this is another message passing layer
+            using_decoder: if True and out_channels is not None, the output layer is a classical MLP on node features,
+                else this is another message passing layer (or None if out_channels is None)
+            act: The non-linear activation function to use after each layer, except for the output layer
+                (existing only if out_channels is not None).
+            act_kwargs: Arguments passed to the respective activation function defined by `act`.
+            **kwargs: passed to message_passing_cls constructor.
+
+        """
+        super().__init__()
+
+        self.supports_edge_attr = supports_edge_attr
+        self.supports_edge_weight = supports_edge_weight
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.num_layers = num_layers
+        self.out_channels = out_channels
+        self.using_encoder = using_encoder
+        self.using_decoder = using_decoder
+        self.message_passing_cls = message_passing_cls
+        self.repeat_hidden_layer = repeat_hidden_layer
+
+        self.dropout = nn.Dropout(p=dropout)
+        self.act = activation_resolver(act, **(act_kwargs or {}))
+
+        # all convolutional for forward pass
+        self._convs_forward = []
+
+        # encoding first layer
+        if self.using_encoder:
+            self.first_layer = nn.Linear(
+                in_features=in_channels, out_features=hidden_channels
+            )
+        else:
+            self.first_layer = self.init_conv(
+                in_channels=in_channels, out_channels=hidden_channels, **kwargs
+            )
+            self._convs_forward.append(self.first_layer)
+
+        # hidden layer(s)
+        if repeat_hidden_layer:
+            # store convolution layers in an attribute to make its parameters be followed
+            self.conv = self.init_conv(
+                in_channels=hidden_channels, out_channels=hidden_channels, **kwargs
+            )
+            self._convs_forward += [self.conv] * self.num_layers  # repeat the layer
+            self.convs = []
+        else:
+            self.conv = None
+            # store convolution layers in module list to make their parameters be followed
+            self.convs = nn.ModuleList()
+            for _ in range(num_layers):
+                conv = self.init_conv(
+                    in_channels=hidden_channels, out_channels=hidden_channels, **kwargs
+                )
+                self.convs.append(conv)
+                self._convs_forward.append(conv)
+
+        # last layer (if out_channels is not None)
+        if self.out_channels is None:
+            self.last_layer = None
+        else:
+            if self.using_decoder:
+                self.last_layer = nn.Linear(
+                    in_features=hidden_channels, out_features=out_channels
+                )
+            else:
+                self.last_layer = self.init_conv(
+                    in_channels=hidden_channels, out_channels=out_channels, **kwargs
+                )
+                self._convs_forward.append(self.last_layer)
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Adj,
+        edge_weight: OptTensor = None,
+        edge_attr: OptTensor = None,
+    ) -> Tensor:
+        """Forward pass
+
+        Args:
+            x: input node features
+            edge_index: edge indices
+            edge_weight: edge weights
+            edge_attr:  edge featrues
+
+        Returns:
+            node embeddings
+
+        """
+        if self.using_encoder:
+            x = self.first_layer(x)
+            x = self.act(x)
+            x = self.dropout(x)
+
+        for i_conv, conv in enumerate(self._convs_forward):
+            if self.supports_edge_weight and self.supports_edge_attr:
+                x = conv(x, edge_index, edge_weight=edge_weight, edge_attr=edge_attr)
+            elif self.supports_edge_weight:
+                x = conv(x, edge_index, edge_weight=edge_weight)
+            elif self.supports_edge_attr:
+                x = conv(x, edge_index, edge_attr=edge_attr)
+            else:
+                x = conv(x, edge_index)
+            if (
+                i_conv < len(self._convs_forward) - 1
+                or self.last_layer is None
+                or self.using_decoder
+            ):
+                x = self.act(x)
+                x = self.dropout(x)
+
+        if self.using_decoder and self.last_layer is not None:
+            x = self.last_layer(x)
+
+        return x
+
+    def reset_parameters(self):
+        r"""Resets all learnable parameters of the module."""
+        for conv in self.convs:
+            conv.reset_parameters()
+        if self.conv is not None:
+            self.conv.reset_parameters()
+        self.first_layer.reset_parameters()
+        if self.last_layer is not None:
+            self.last_layer.reset_parameters()
+
+    def init_conv(
+        self, in_channels: Union[int, tuple[int, int]], out_channels: int, **kwargs
+    ) -> MessagePassing:
+        return self.message_passing_cls(in_channels, out_channels, **kwargs)

--- a/tests/solvers/python/conftest.py
+++ b/tests/solvers/python/conftest.py
@@ -600,9 +600,8 @@ class MyGNN(thg.nn.models.GAT):
         return self.LOG_SENTENCE + f" custom_param={self.custom_param}"
 
 
-def my_gnn_kwargs_fn(node_features_dim: int, gnn_out_dim: int) -> dict[str, Any]:
+def my_gnn_kwargs_fn(gnn_out_dim: int) -> dict[str, Any]:
     return dict(
-        in_channels=node_features_dim,
         hidden_channels=gnn_out_dim,
         num_layers=2,
         dropout=0.2,

--- a/tests/solvers/python/test_gnn_ray_rllib.py
+++ b/tests/solvers/python/test_gnn_ray_rllib.py
@@ -60,15 +60,9 @@ def test_ppo_user_gnn(
     caplog,
 ):
     domain_factory = unmasked_jsp_domain_factory
-    domain = domain_factory()
-    node_features_dim = int(
-        np.prod(domain.get_observation_space().unwrapped().node_space.shape)
-    )
     gnn_out_dim = 64
     gnn_class = my_gnn_class
-    gnn_kwargs = my_gnn_kwargs(
-        node_features_dim=node_features_dim, gnn_out_dim=gnn_out_dim
-    )
+    gnn_kwargs = my_gnn_kwargs(gnn_out_dim=gnn_out_dim)
 
     solver_kwargs = dict(
         algo_class=GraphPPO,
@@ -93,7 +87,7 @@ def test_ppo_user_gnn(
             render=False,
         )
 
-    assert gnn_class(**gnn_kwargs).warning() in caplog.text
+    assert gnn_class(in_channels=1, **gnn_kwargs).warning() in caplog.text
 
 
 def test_ppo_user_reduction_layer(
@@ -207,14 +201,9 @@ def test_ppo_masked_user_gnn(
     caplog,
 ):
     domain_factory = jsp_domain_factory
-    node_features_dim = int(
-        np.prod(domain_factory().get_observation_space().unwrapped().node_space.shape)
-    )
     gnn_out_dim = 64
     gnn_class = my_gnn_class
-    gnn_kwargs = my_gnn_kwargs(
-        node_features_dim=node_features_dim, gnn_out_dim=gnn_out_dim
-    )
+    gnn_kwargs = my_gnn_kwargs(gnn_out_dim=gnn_out_dim)
 
     solver_kwargs = dict(
         algo_class=GraphPPO,
@@ -232,7 +221,7 @@ def test_ppo_masked_user_gnn(
         assert solver._action_masking and solver._is_graph_obs
         with caplog.at_level(logging.WARNING):
             solver.solve()
-    assert gnn_class(**gnn_kwargs).warning() in caplog.text
+    assert gnn_class(in_channels=1, **gnn_kwargs).warning() in caplog.text
 
 
 def test_dict_ppo_masked_user_gnn(
@@ -244,19 +233,9 @@ def test_dict_ppo_masked_user_gnn(
     caplog,
 ):
     domain_factory = jsp_dict_domain_factory
-    node_features_dim = int(
-        np.prod(
-            domain_factory()
-            .get_observation_space()
-            .unwrapped()["graph"]
-            .node_space.shape
-        )
-    )
     gnn_out_dim = 64
     gnn_class = my_gnn_class
-    gnn_kwargs = my_gnn_kwargs(
-        node_features_dim=node_features_dim, gnn_out_dim=gnn_out_dim
-    )
+    gnn_kwargs = my_gnn_kwargs(gnn_out_dim=gnn_out_dim)
 
     solver_kwargs = dict(
         algo_class=GraphPPO,
@@ -274,7 +253,7 @@ def test_dict_ppo_masked_user_gnn(
         assert solver._action_masking and solver._is_graph_multiinput_obs
         with caplog.at_level(logging.WARNING):
             solver.solve()
-    assert gnn_class(**gnn_kwargs).warning() in caplog.text
+    assert gnn_class(in_channels=1, **gnn_kwargs).warning() in caplog.text
 
 
 def test_graph2node_ppo(

--- a/tests/solvers/python/test_gnn_sb3.py
+++ b/tests/solvers/python/test_gnn_sb3.py
@@ -38,6 +38,7 @@ def test_ppo(unmasked_graph_domain_factory):
         algo_class=GraphPPO,
         baselines_policy="GraphInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
     ) as solver:
 
         solver.solve()
@@ -76,6 +77,7 @@ def test_a2c(unmasked_jsp_domain_factory):
         algo_class=GraphA2C,
         baselines_policy="GraphInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
     ) as solver:
 
         solver.solve()
@@ -90,20 +92,15 @@ def test_a2c(unmasked_jsp_domain_factory):
 
 def test_ppo_user_gnn(caplog, unmasked_jsp_domain_factory, my_gnn_class, my_gnn_kwargs):
     domain_factory = unmasked_jsp_domain_factory
-    domain = domain_factory()
-    node_features_dim = int(
-        np.prod(domain.get_observation_space().unwrapped().node_space.shape)
-    )
     gnn_out_dim = 64
     gnn_class = my_gnn_class
-    gnn_kwargs = my_gnn_kwargs(
-        node_features_dim=node_features_dim, gnn_out_dim=gnn_out_dim
-    )
+    gnn_kwargs = my_gnn_kwargs(gnn_out_dim=gnn_out_dim)
     with StableBaseline(
         domain_factory=domain_factory,
         algo_class=GraphPPO,
         baselines_policy="GraphInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
         policy_kwargs=dict(
             features_extractor_class=GraphFeaturesExtractor,
             features_extractor_kwargs=dict(
@@ -123,7 +120,7 @@ def test_ppo_user_gnn(caplog, unmasked_jsp_domain_factory, my_gnn_class, my_gnn_
             num_episodes=1,
             render=False,
         )
-    assert gnn_class(**gnn_kwargs).warning() in caplog.text
+    assert gnn_class(in_channels=1, **gnn_kwargs).warning() in caplog.text
 
 
 def test_ppo_user_reduction_layer(
@@ -145,6 +142,7 @@ def test_ppo_user_reduction_layer(
         algo_class=GraphPPO,
         baselines_policy="GraphInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
         policy_kwargs=dict(
             features_extractor_class=GraphFeaturesExtractor,
             features_extractor_kwargs=dict(
@@ -174,6 +172,7 @@ def test_maskable_ppo(graph_domain_factory):
         algo_class=MaskableGraphPPO,
         baselines_policy="GraphInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
         use_action_masking=True,
     ) as solver:
 
@@ -201,6 +200,7 @@ def test_dict_ppo(unmasked_jsp_dict_domain_factory):
         algo_class=GraphPPO,
         baselines_policy="MultiInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
     ) as solver:
 
         solver.solve()
@@ -220,6 +220,7 @@ def test_dict_maskable_ppo(jsp_dict_domain_factory):
         algo_class=MaskableGraphPPO,
         baselines_policy="MultiInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
         use_action_masking=True,
     ) as solver:
 
@@ -245,6 +246,7 @@ def test_dict_a2c(unmasked_jsp_dict_domain_factory):
         algo_class=GraphA2C,
         baselines_policy="MultiInputPolicy",
         learn_config={"total_timesteps": 100},
+        n_steps=100,
     ) as solver:
         solver.solve()
         rollout(

--- a/tests/solvers/python/test_gnn_utils.py
+++ b/tests/solvers/python/test_gnn_utils.py
@@ -1,0 +1,87 @@
+import torch as th
+import torch_geometric as thg
+from pytest_cases import fixture, param_fixture
+
+from skdecide.hub.solver.utils.gnn.advanced_gnn import AdvancedGNN
+
+
+@fixture
+def data():
+    edge_index = th.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=th.long)
+    x = th.tensor([[-1, 1], [0, 1], [1, 5]], dtype=th.float)
+    edge_weight = th.tensor([0, 1, 2, 3], dtype=th.float)
+    edge_attr = th.ones((4, 2))
+    return thg.data.Data(
+        x=x, edge_index=edge_index, edge_attr=edge_attr, edge_weight=edge_weight
+    )
+
+
+out_channels = param_fixture("out_channels", [4, None])
+using_encoder = param_fixture("using_encoder", [True, False])
+using_decoder = param_fixture("using_decoder", [True, False])
+repeat_hidden_layer = param_fixture("repeat_hidden_layer", [True, False])
+
+
+def test_advanced_gnn(
+    data, out_channels, using_encoder, using_decoder, repeat_hidden_layer
+):
+    x, edge_index, edge_attr, edge_weight = (
+        data.x,
+        data.edge_index,
+        data.edge_attr,
+        data.edge_weight,
+    )
+    in_channels = x.shape[1]
+    hidden_channels = 16
+    num_layers = 3
+    message_passing_cls = thg.nn.GCNConv
+    supports_edge_weight = True
+    supports_edge_attr = False
+
+    gnn = AdvancedGNN(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        hidden_channels=hidden_channels,
+        num_layers=num_layers,
+        message_passing_cls=message_passing_cls,
+        supports_edge_weight=supports_edge_weight,
+        supports_edge_attr=supports_edge_attr,
+        using_encoder=using_encoder,
+        using_decoder=using_decoder,
+        repeat_hidden_layer=repeat_hidden_layer,
+    )
+
+    if using_encoder:
+        assert isinstance(gnn.first_layer, th.nn.Linear)
+    else:
+        assert isinstance(gnn.first_layer, message_passing_cls)
+    if out_channels is None:
+        assert gnn.last_layer is None
+    else:
+        if using_decoder:
+            assert isinstance(gnn.last_layer, th.nn.Linear)
+        else:
+            assert isinstance(gnn.last_layer, message_passing_cls)
+    if repeat_hidden_layer:
+        assert isinstance(gnn.conv, thg.nn.GCNConv)
+        assert len(gnn.convs) == 0
+    else:
+        assert gnn.conv is None
+        assert len(gnn.convs) == num_layers
+        assert isinstance(gnn.convs[0], thg.nn.GCNConv)
+
+    n_params = 2  # first layer
+    if repeat_hidden_layer:
+        n_params += 2  # hidden layer
+    else:
+        n_params += 2 * (num_layers)  # hidden layers
+    if out_channels is not None:
+        n_params += 2  # last layer
+    assert len(list(gnn.parameters())) == n_params
+
+    y = gnn(x=x, edge_index=edge_index, edge_weight=edge_weight, edge_attr=edge_attr)
+
+    if out_channels is None:
+        assert y.shape == (x.shape[0], hidden_channels)
+    else:
+        assert y.shape == (x.shape[0], out_channels)


### PR DESCRIPTION
As `thg.nn.models.basic_gnn.BasicGNN`, it wraps `MessagePassing` layers. Main differences:
- possibility to add an encoding/decoding layer as first/last layer (a plain MLP on nodes features)
- possibility to repeat a single convolutional layer instead of duplicate it (less params to learn)

We add tests to showcase its use with autoregressive graph PPO algorithm.

To make it easier to the user, we update `GraphFeaturesExtractor` and `Graph2NodeLayer` so that they automatically fill the arg `in_channels` (and `out_channels` for the latter) from the observation space dimension.