### PR TITLE
Allow to load a sb3 autoregressive graph ppo on different action space

### DIFF
--- a/skdecide/hub/domain/plado/plado.py
+++ b/skdecide/hub/domain/plado/plado.py
@@ -343,6 +343,11 @@ class BasePladoDomain(D):
         else:
             raise NotImplementedError()
 
+    def repr_obs_as_plado(self, obs: D.T_observation) -> str:
+        """Return a string representation of the observation similar to plado representation."""
+        plado_state = self._translate_state_to_plado(obs)
+        return f"PladoState(atoms={plado_state.atoms}, fluents={plado_state.fluents})"
+
     def _translate_state_to_plado(self, state: D.T_state) -> PladoState:
         if self.state_encoding == StateEncoding.NATIVE:
             return state.to_plado()

--- a/skdecide/hub/solver/stable_baselines/autoregressive/common/policies.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/common/policies.py
@@ -826,7 +826,9 @@ class AutoregressiveGraph2NodeActorCriticPolicy(AutoregressiveGNNActorCriticPoli
         if not isinstance(action_space, spaces.MultiDiscrete):
             raise ValueError("action_space must be a multidiscrete space.")
         if n_graph2node_components is None:
-            self.n_graph2node_components = len(action_space.nvec) - 1
+            self.n_graph2node_components = self.default_n_graph2node_components(
+                action_space
+            )
         else:
             self.n_graph2node_components = n_graph2node_components
         if action_gnn_kwargs is None:
@@ -840,6 +842,11 @@ class AutoregressiveGraph2NodeActorCriticPolicy(AutoregressiveGNNActorCriticPoli
             lr_schedule,
             **kwargs,
         )
+
+    @staticmethod
+    def default_n_graph2node_components(action_space: spaces.MultiDiscrete) -> int:
+        """Default number of action components that are graph nodes if not specified."""
+        return len(action_space.nvec) - 1
 
 
 class AutoregressiveHeteroGraph2NodeActorCriticPolicy(
@@ -901,9 +908,6 @@ class AutoregressiveHeteroGraph2NodeActorCriticPolicy(
         if not isinstance(action_space, spaces.MultiDiscrete):
             raise ValueError("action_space must be a multidiscrete space.")
 
-        if n_graph2node_components is None:
-            n_graph2node_components = len(action_space.nvec)
-
         super().__init__(
             observation_space=observation_space,
             action_space=action_space,
@@ -916,3 +920,8 @@ class AutoregressiveHeteroGraph2NodeActorCriticPolicy(
 
         # init action_components_node_flag_indices after super().__init__() to avoid to be overriden
         self.action_components_node_flag_indices = action_components_node_flag_indices
+
+    @staticmethod
+    def default_n_graph2node_components(action_space: spaces.MultiDiscrete) -> int:
+        """Default number of action components that are graph nodes if not specified."""
+        return len(action_space.nvec)

--- a/skdecide/hub/solver/stable_baselines/autoregressive/ppo/autoregressive_ppo.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/ppo/autoregressive_ppo.py
@@ -1,7 +1,14 @@
-from typing import ClassVar
+import io
+import pathlib
+from typing import Any, ClassVar, Dict, Optional, Type, Union
 
+import gymnasium as gym
+import torch as th
 from sb3_contrib import MaskablePPO
+from stable_baselines3.common.base_class import SelfBaseAlgorithm
 from stable_baselines3.common.policies import BasePolicy
+from stable_baselines3.common.save_util import load_from_zip_file, save_to_zip_file
+from stable_baselines3.common.type_aliases import GymEnv
 
 from skdecide.hub.solver.stable_baselines.autoregressive.common.on_policy_algorithm import (
     ApplicableActionsGraphOnPolicyAlgorithm,
@@ -54,3 +61,79 @@ class AutoregressiveGraphPPO(
         "Graph2NodePolicy": AutoregressiveGraph2NodeActorCriticPolicy,
         "HeteroGraph2NodePolicy": AutoregressiveHeteroGraph2NodeActorCriticPolicy,
     }
+
+    @classmethod
+    def load(  # noqa: C901
+        cls: Type[SelfBaseAlgorithm],
+        path: Union[str, pathlib.Path, io.BufferedIOBase],
+        env: Optional[GymEnv] = None,
+        device: Union[th.device, str] = "auto",
+        custom_objects: Optional[Dict[str, Any]] = None,
+        print_system_info: bool = False,
+        force_reset: bool = True,
+        **kwargs,
+    ) -> SelfBaseAlgorithm:
+        try:
+            return super().load(
+                path=path,
+                env=env,
+                device=device,
+                custom_objects=custom_objects,
+                print_system_info=print_system_info,
+                force_reset=force_reset,
+                **kwargs,
+            )
+        except ValueError as e:
+            # maybe error because different actions spaces (ex: apply on same pddl domain, different problem)
+            # can be ok if same number of components and dim differ only for graph2node components,
+            # but we need to update the action space
+            data, params, pytorch_variables = load_from_zip_file(path)  # stored params
+            if issubclass(
+                data["policy_class"], AutoregressiveGraph2NodeActorCriticPolicy
+            ):
+                if (
+                    "policy_kwargs" not in data
+                    or "n_graph2node_components" not in data["policy_kwargs"]
+                ):
+                    n_graph2node_components = data[
+                        "policy_class"
+                    ].default_n_graph2node_components(data["action_space"])
+                else:
+                    n_graph2node_components = data["policy_kwargs"][
+                        "n_graph2node_components"
+                    ]
+                # check action spaces have still same length
+                assert isinstance(env.action_space, gym.spaces.MultiDiscrete)
+                assert len(env.action_space.nvec) == len(
+                    data["action_space"].nvec
+                ), f"Action spaces must have same length: len({env.action_space}.nvec) != len({data['action_space']}.nvec)"
+                # check independent from graph component have same dim
+                for i_component in range(
+                    len(env.action_space.nvec) - n_graph2node_components
+                ):
+                    assert (
+                        env.action_space.nvec[i_component]
+                        == data["action_space"].nvec[i_component]
+                    ), f"Action spaces independent components must have same dim: comp #{i_component} of {env.action_space} and {data['action_space']}"
+
+                # update action space
+                data["action_space"] = env.action_space
+                # create in-memory storage with updated data and retry loading from it
+                with io.BytesIO() as file:
+                    save_to_zip_file(
+                        file,
+                        data=data,
+                        params=params,
+                        pytorch_variables=pytorch_variables,
+                    )
+                    return super().load(
+                        path=file,
+                        env=env,
+                        device=device,
+                        custom_objects=custom_objects,
+                        print_system_info=print_system_info,
+                        force_reset=force_reset,
+                        **kwargs,
+                    )
+            # else still error
+            raise e

--- a/skdecide/hub/solver/stable_baselines/stable_baselines.py
+++ b/skdecide/hub/solver/stable_baselines/stable_baselines.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any, Optional, Union
 
@@ -32,6 +33,8 @@ from skdecide.builders.domain import (
 from skdecide.builders.solver import Maskable, Policies, Restorable
 from skdecide.hub.domain.gym import AsGymnasiumEnv
 from skdecide.hub.space.gym import GymSpace, MultiDiscreteSpace
+
+logger = logging.getLogger(__name__)
 
 
 class D(Domain, SingleAgent, Sequential, UnrestrictedActions, Initializable):
@@ -244,7 +247,13 @@ class StableBaseline(Solver, Policies, Restorable, Maskable):
         self._algo.save(path)
 
     def _load(self, path: str):
-        self._algo = self._algo_class.load(path, env=self._learning_env)
+        load_algo_kwargs = dict(self._algo_kwargs)
+        if "policy_kwargs" in load_algo_kwargs:
+            logger.warning("load(): ignoring 'policy_kwargs'.")
+            load_algo_kwargs.pop("policy_kwargs")
+        self._algo = self._algo_class.load(
+            path, env=self._learning_env, **load_algo_kwargs
+        )
 
     def get_policy(self) -> BasePolicy:
         """Return the computed policy."""

--- a/skdecide/utils.py
+++ b/skdecide/utils.py
@@ -245,6 +245,9 @@ def rollout(
     verbose: bool = True,
     action_formatter: Optional[Callable[[D.T_event], str]] = lambda a: str(a),
     outcome_formatter: Optional[Callable[[EnvironmentOutcome], str]] = lambda o: str(o),
+    observation_formatter: Optional[Callable[[D.T_observation], str]] = lambda o: str(
+        o
+    ),
     return_episodes: bool = False,
     goal_logging_level: int = logging.INFO,
     rollout_callback: Optional[RolloutCallback] = None,
@@ -272,6 +275,7 @@ def rollout(
     verbose: Whether to print information to the console during rollout.
     action_formatter: The function transforming actions in the string to print (if None, no print).
     outcome_formatter: The function transforming EnvironmentOutcome objects in the string to print (if None, no print).
+    observation_formatter: The function transforming Observation objects in the string to print (if None, no print).
     return_episodes: if True, return the list of episodes, each episode as a tuple of observations, actions, and values.
         else return nothing.
     goal_logging_level: logging level at which we want to display if goal has been reached or not
@@ -383,8 +387,11 @@ def rollout(
                 raise ValueError(
                     "from_memory must be None if domain has no set_memory() method."
                 )
-        logger.debug(f"Episode {i_episode + 1} started with following observation:")
-        logger.debug(observation)
+        if observation_formatter is not None:
+            logger.debug(f"Episode {i_episode + 1} started with following observation:")
+            logger.debug(observation_formatter(observation))
+        else:
+            logger.debug(f"Episode {i_episode + 1} starting")
         # Run episode
         step = 1
 


### PR DESCRIPTION
When some action components are graph nodes, the algo can apply on a different action space. 
Still
- `len(action_space.nvec)` ie nb of action components cannot change (as the model has a network by component)
- independent components must keep the same dim (as it is hard coded in the network in that case)

This can be useful when training a autoregressive GNN model on a PDDL domain and then apply on a similar pddl domain but different problem (with same actions but different objects).

To achieve that we just need to be careful to update the algo action space. The parameters of the torch layers are still loaded as
before.

We also updated `StableBaseline.load()` to take into account new algo params, as `n_steps` or `learning_rate`.

The autoregressive example on pddl blocksworld domain with LLG encoding has been updated to show this new feature.