### PR TITLE
Add GPU support to autoregressive GNNs

### DIFF
--- a/skdecide/hub/solver/stable_baselines/autoregressive/common/distributions.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/common/distributions.py
@@ -127,6 +127,7 @@ class MultiMaskableCategoricalDistribution(Distribution):
                     # add only contribution for valid samples
                     marginal_logp = th.zeros(
                         self.get_proba_distribution_component_batch_shape(i_component),
+                        device=x.device,
                         dtype=x.dtype,
                     )
                     ind_valid_samples = self._ind_valid_samples_by_distributions[
@@ -155,6 +156,7 @@ class MultiMaskableCategoricalDistribution(Distribution):
                     # add only contribution for valid samples
                     marginal_entropy = th.zeros(
                         self.get_proba_distribution_component_batch_shape(i_component),
+                        device=distribution.distribution.probs.device,
                         dtype=marginal_dist.logits.dtype,
                     )
                     ind_valid_samples = self._ind_valid_samples_by_distributions[

--- a/skdecide/hub/solver/stable_baselines/autoregressive/common/policies.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/common/policies.py
@@ -337,6 +337,7 @@ class AutoregressiveActorCriticPolicy(MaskableActorCriticPolicy):
                     encoded_graph_independent_action_components[enriched_obs.batch, :],
                     th.zeros(
                         (len(enriched_obs.x), self.n_graph2node_components),
+                        device=self.device,
                         dtype=enriched_obs.x.dtype,
                     ),
                 ),
@@ -487,7 +488,7 @@ class AutoregressiveActorCriticPolicy(MaskableActorCriticPolicy):
                 ]
                 component_nodes = (
                     (  # shift node ids to match node ids in the batched graph
-                        actions_component + node_shift_by_sample
+                        actions_component + node_shift_by_sample.to(self.device)
                     )[actions_component >= 0].long()
                 )  # keep only relevant samples (remove -1 components)
                 # NB: avoid torch.autograd.backward issue, we cannot change inplace node features
@@ -578,7 +579,7 @@ class AutoregressiveActorCriticPolicy(MaskableActorCriticPolicy):
             enriched_obs = None
 
         # action components
-        action_components = th.as_tensor([], dtype=int)
+        action_components = th.as_tensor([], device=self.device, dtype=int)
         for (
             i_action_component,
             (
@@ -717,6 +718,7 @@ class AutoregressiveActorCriticPolicy(MaskableActorCriticPolicy):
                         len(enriched_obs.x),
                         self.n_graph2node_components,
                     ),
+                    device=self.device,
                     dtype=enriched_obs.x.dtype,
                 ),
             ),


### PR DESCRIPTION
This fixes the usage of autoregressive GNN via sb3 when using GPU. 
Some device specifications were missing.