### PR TITLE
Remove intermediate methods not supposed to be overriden by the user

### DIFF
--- a/examples/gnn/domains.py
+++ b/examples/gnn/domains.py
@@ -169,12 +169,12 @@ class GraphMaze(D):
         maze_memory = self._graph2mazestate(memory)
         self.maze_domain._render_from(memory=maze_memory, **kwargs)
 
-    def _get_action_mask(
+    def _get_action_mask_from(
         self, memory: Optional[D.T_memory[D.T_state]] = None
     ) -> D.T_agent[Mask]:
         # a different way to display applicable actions
-        # we could also override only _get_applicable_action() but it will be more computationally efficient to
-        # implement directly get_action_mask()
+        # we could also override only _get_applicable_action_from() but it will be more computationally efficient to
+        # implement directly _get_action_mask_from()
         if memory is None:
             memory = self._memory
         mazestate_memory = self._graph2mazestate(memory)
@@ -196,7 +196,7 @@ class GraphMaze(D):
                 action
                 for action, mask in zip(
                     self._get_action_space().get_elements(),
-                    self._get_action_mask(memory=memory),
+                    self._get_action_mask_from(memory=memory),
                 )
                 if mask
             ]

--- a/skdecide/builders/domain/dynamics.py
+++ b/skdecide/builders/domain/dynamics.py
@@ -48,49 +48,14 @@ class Environment:
     ]:
         """Run one step of the environment's dynamics.
 
-        By default, #Environment.step() provides some boilerplate code and internally calls #Environment._step() (which
-        returns a transition outcome). The boilerplate code automatically stores next state into the #_memory attribute
-        and samples a corresponding observation.
-
-        !!! tip
-            Whenever an existing environment needs to be wrapped instead of implemented fully in scikit-decide (e.g. compiled
-            ATARI games), it is recommended to overwrite #Environment.step() to call the external environment and not
-            use the #Environment._step() helper function.
+        By default, #Environment.step() provides some boilerplate code and internally calls #Environment._state_step()
+        (which returns a transition outcome). The boilerplate code automatically stores next state into the
+        #_memory attribute and samples a corresponding observation.
+        It also autocasts itself to be used at the proper characteristics level by each solver.
 
         !!! warning
             Before calling #Environment.step() the first time or when the end of an episode is
             reached, #Initializable.reset() must be called to reset the environment's state.
-
-        # Parameters
-        action: The action taken in the current memory (state or history) triggering the transition.
-
-        # Returns
-        The environment outcome of this step.
-        """
-        return self._step(action)
-
-    def _step(
-        self, action: D.T_agent[D.T_concurrency[D.T_event]]
-    ) -> EnvironmentOutcome[
-        D.T_agent[D.T_observation],
-        D.T_agent[Value[D.T_value]],
-        D.T_agent[D.T_predicate],
-        D.T_agent[D.T_info],
-    ]:
-        """Run one step of the environment's dynamics.
-
-        By default, #Environment._step() provides some boilerplate code and internally
-        calls #Environment._state_step() (which returns a transition outcome). The boilerplate code automatically stores
-        next state into the #_memory attribute and samples a corresponding observation.
-
-        !!! tip
-            Whenever an existing environment needs to be wrapped instead of implemented fully in scikit-decide (e.g. compiled
-            ATARI games), it is recommended to overwrite #Environment._step() to call the external environment and not
-            use the #Environment._state_step() helper function.
-
-        !!! warning
-            Before calling #Environment._step() the first time or when the end of an episode is
-            reached, #Initializable._reset() must be called to reset the environment's state.
 
         # Parameters
         action: The action taken in the current memory (state or history) triggering the transition.
@@ -212,44 +177,10 @@ class Simulation(Environment):
     ]:
         """Sample one transition of the simulator's dynamics.
 
-        By default, #Simulation.sample() provides some boilerplate code and internally calls #Simulation._sample()
+        By default, #Simulation.sample() provides some boilerplate code and internally calls #Simulation._state_sample()
         (which returns a transition outcome). The boilerplate code automatically samples an observation corresponding to
         the sampled next state.
-
-        !!! tip
-            Whenever an existing simulator needs to be wrapped instead of implemented fully in scikit-decide (e.g. a
-            simulator), it is recommended to overwrite #Simulation.sample() to call the external simulator and not use
-            the #Simulation._sample() helper function.
-
-        # Parameters
-        memory: The source memory (state or history) of the transition.
-        action: The action taken in the given memory (state or history) triggering the transition.
-
-        # Returns
-        The environment outcome of the sampled transition.
-        """
-        return self._sample(memory, action)
-
-    def _sample(
-        self,
-        memory: D.T_memory[D.T_state],
-        action: D.T_agent[D.T_concurrency[D.T_event]],
-    ) -> EnvironmentOutcome[
-        D.T_agent[D.T_observation],
-        D.T_agent[Value[D.T_value]],
-        D.T_agent[D.T_predicate],
-        D.T_agent[D.T_info],
-    ]:
-        """Sample one transition of the simulator's dynamics.
-
-        By default, #Simulation._sample() provides some boilerplate code and internally
-        calls #Simulation._state_sample() (which returns a transition outcome). The boilerplate code automatically
-        samples an observation corresponding to the sampled next state.
-
-        !!! tip
-            Whenever an existing simulator needs to be wrapped instead of implemented fully in scikit-decide (e.g. a
-            simulator), it is recommended to overwrite #Simulation._sample() to call the external simulator and not use
-            the #Simulation._state_sample() helper function.
+        It also autocasts itself to be used at the proper characteristics level by each solver.
 
         # Parameters
         memory: The source memory (state or history) of the transition.

--- a/skdecide/builders/domain/events.py
+++ b/skdecide/builders/domain/events.py
@@ -25,32 +25,16 @@ class Events:
         history), or in the internal one if omitted.
 
         By default, #Events.get_enabled_events() provides some boilerplate code and internally
-        calls #Events._get_enabled_events(). The boilerplate code automatically passes the #_memory attribute instead of
+        calls #Events._get_enabled_events_from(). The boilerplate code automatically passes the #_memory attribute instead of
         the memory parameter whenever the latter is None.
+        It also autocasts itself to be used at the proper characteristics level by each solver.
 
         # Parameters
         memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
 
         # Returns
         The space of enabled events.
-        """
-        return self._get_enabled_events(memory)
 
-    def _get_enabled_events(
-        self, memory: Optional[D.T_memory[D.T_state]] = None
-    ) -> Space[D.T_event]:
-        """Get the space (finite or infinite set) of enabled uncontrollable events in the given memory (state or
-        history), or in the internal one if omitted.
-
-        By default, #Events._get_enabled_events() provides some boilerplate code and internally
-        calls #Events._get_enabled_events_from(). The boilerplate code automatically passes the #_memory attribute
-        instead of the memory parameter whenever the latter is None.
-
-        # Parameters
-        memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
-
-        # Returns
-        The space of enabled events.
         """
         if memory is None:
             memory = self._memory
@@ -81,32 +65,16 @@ class Events:
         internal one if omitted.
 
         By default, #Events.is_enabled_event() provides some boilerplate code and internally
-        calls #Events._is_enabled_event(). The boilerplate code automatically passes the #_memory attribute instead of
+        calls #Events._is_enabled_event_from(). The boilerplate code automatically passes the #_memory attribute instead of
         the memory parameter whenever the latter is None.
+        It also autocasts itself to be used at the proper characteristics level by each solver.
 
         # Parameters
         memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
 
         # Returns
         True if the event is enabled (False otherwise).
-        """
-        return self._is_enabled_event(event, memory)
 
-    def _is_enabled_event(
-        self, event: D.T_event, memory: Optional[D.T_memory[D.T_state]] = None
-    ) -> bool:
-        """Indicate whether an uncontrollable event is enabled in the given memory (state or history), or in the
-        internal one if omitted.
-
-        By default, #Events._is_enabled_event() provides some boilerplate code and internally
-        calls #Events._is_enabled_event_from(). The boilerplate code automatically passes the #_memory attribute instead
-        of the memory parameter whenever the latter is None.
-
-        # Parameters
-        memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
-
-        # Returns
-        True if the event is enabled (False otherwise).
         """
         if memory is None:
             memory = self._memory
@@ -213,32 +181,16 @@ class Events:
         the internal one if omitted.
 
         By default, #Events.get_applicable_actions() provides some boilerplate code and internally
-        calls #Events._get_applicable_actions(). The boilerplate code automatically passes the #_memory attribute
-        instead of the memory parameter whenever the latter is None.
-
-        # Parameters
-        memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
-
-        # Returns
-        The space of applicable actions.
-        """
-        return self._get_applicable_actions(memory)
-
-    def _get_applicable_actions(
-        self, memory: Optional[D.T_memory[D.T_state]] = None
-    ) -> D.T_agent[Space[D.T_event]]:
-        """Get the space (finite or infinite set) of applicable actions in the given memory (state or history), or in
-        the internal one if omitted.
-
-        By default, #Events._get_applicable_actions() provides some boilerplate code and internally
         calls #Events._get_applicable_actions_from(). The boilerplate code automatically passes the #_memory attribute
         instead of the memory parameter whenever the latter is None.
+        It also autocasts itself to be used at the proper characteristics level by each solver.
 
         # Parameters
         memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
 
         # Returns
         The space of applicable actions.
+
         """
         if memory is None:
             memory = self._memory
@@ -270,28 +222,8 @@ class Events:
         omitted.
 
         By default, #Events.is_applicable_action() provides some boilerplate code and internally
-        calls #Events._is_applicable_action(). The boilerplate code automatically passes the #_memory attribute instead
+        calls #Events._is_applicable_action_from(), with the #_memory attribute instead
         of the memory parameter whenever the latter is None.
-
-        # Parameters
-        memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
-
-        # Returns
-        True if the action is applicable (False otherwise).
-        """
-        return self._is_applicable_action(action, memory)
-
-    def _is_applicable_action(
-        self,
-        action: D.T_agent[D.T_event],
-        memory: Optional[D.T_memory[D.T_state]] = None,
-    ) -> bool:
-        """Indicate whether an action is applicable in the given memory (state or history), or in the internal one if
-        omitted.
-
-        By default, #Events._is_applicable_action() provides some boilerplate code and internally
-        calls #Events._is_applicable_action_from(). The boilerplate code automatically passes the #_memory attribute
-        instead of the memory parameter whenever the latter is None.
 
         # Parameters
         memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
@@ -338,8 +270,9 @@ class Events:
         space can be iterated over in some way. It is represented by a flat array of 0's and 1's ordered as the actions
         when enumerated: 1 for an applicable action, and 0 for a not applicable action.
 
-        More precisely, this implementation makes the assumption that each agent action space is an `EnumerableSpace`,
-        and calls internally `self.get_applicable_action()`.
+        By default, #Events.get_action_mask() provides some boilerplate code and internally
+        calls #Events._get_action_mask_from(), with the #_memory attribute instead
+        of the memory parameter whenever the latter is None.
 
         The action mask is used for instance by RL solvers to shut down logits associated to non-applicable actions in
         the output of their internal neural network.
@@ -351,18 +284,18 @@ class Events:
         a numpy array (or dict agent-> numpy array for multi-agent domains) with 0-1 indicating applicability of
         the action (1 meaning applicable and 0 not applicable)
         """
-        return self._get_action_mask(memory=memory)
+        if memory is None:
+            memory = self._memory
+        return self._get_action_mask_from(memory=memory)
 
-    def _get_action_mask(
-        self, memory: Optional[D.T_memory[D.T_state]] = None
-    ) -> D.T_agent[Mask]:
+    def _get_action_mask_from(self, memory: D.T_memory[D.T_state]) -> D.T_agent[Mask]:
         """Get action mask for the given memory or internal one if omitted.
 
         An action mask is another (more specific) format for applicable actions, that has a meaning only if the action
         space can be iterated over in some way. It is represented by a flat array of 0's and 1's ordered as the actions
         when enumerated: 1 for an applicable action, and 0 for a not applicable action.
 
-        More precisely, this implementation makes the assumption that each agent action space is an `EnumerableSpace`,
+        The default implementation makes the assumption that each agent action space is an `EnumerableSpace`,
         and calls internally `self.get_applicable_action()`.
 
         The action mask is used for instance by RL solvers to shut down logits associated to non-applicable actions in
@@ -375,7 +308,7 @@ class Events:
         a numpy array (or dict agent-> numpy array for multi-agent domains) with 0-1 indicating applicability of
         the action (1 meaning applicable and 0 not applicable)
         """
-        applicable_actions = self._get_applicable_actions(memory=memory)
+        applicable_actions = self._get_applicable_actions_from(memory=memory)
         action_space = self._get_action_space()
         if self.T_agent == Union:
             # single agent

--- a/skdecide/builders/domain/initialization.py
+++ b/skdecide/builders/domain/initialization.py
@@ -18,21 +18,10 @@ class Initializable:
     def reset(self) -> D.T_agent[D.T_observation]:
         """Reset the state of the environment and return an initial observation.
 
-        By default, #Initializable.reset() provides some boilerplate code and internally calls #Initializable._reset()
-        (which returns an initial state). The boilerplate code automatically stores the initial state into the #_memory
-        attribute and samples a corresponding observation.
-
-        # Returns
-        An initial observation.
-        """
-        return self._reset()
-
-    def _reset(self) -> D.T_agent[D.T_observation]:
-        """Reset the state of the environment and return an initial observation.
-
-        By default, #Initializable._reset() provides some boilerplate code and internally
-        calls #Initializable._state_reset() (which returns an initial state). The boilerplate code automatically stores
+        By default, #Initializable.reset() provides some boilerplate code and internally calls
+        #Initializable._state_reset() (which returns an initial state). The boilerplate code automatically stores
         the initial state into the #_memory attribute and samples a corresponding observation.
+        It also autocasts itself to be used at the proper characteristics level by each solver.
 
         # Returns
         An initial observation.

--- a/skdecide/builders/domain/renderability.py
+++ b/skdecide/builders/domain/renderability.py
@@ -20,32 +20,17 @@ class Renderable:
     ) -> Any:
         """Compute a visual render of the given memory (state or history), or the internal one if omitted.
 
-        By default, #Renderable.render() provides some boilerplate code and internally calls #Renderable._render(). The
-        boilerplate code automatically passes the #_memory attribute instead of the memory parameter whenever the latter
-        is None.
+        By default, #Renderable.render() provides some boilerplate code and internally calls #Renderable._render_from().
+        The boilerplate code automatically passes the #_memory attribute instead of the memory parameter whenever
+        the latter is None.
+        It also autocasts itself to be used at the proper characteristics level by each solver.
 
         # Parameters
         memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
 
         # Returns
         A render (e.g. image) or nothing (if the function handles the display directly).
-        """
-        return self._render(memory, **kwargs)
 
-    def _render(
-        self, memory: Optional[D.T_memory[D.T_state]] = None, **kwargs: Any
-    ) -> Any:
-        """Compute a visual render of the given memory (state or history), or the internal one if omitted.
-
-        By default, #Renderable._render() provides some boilerplate code and internally
-        calls #Renderable._render_from(). The boilerplate code automatically passes the #_memory attribute instead of
-        the memory parameter whenever the latter is None.
-
-        # Parameters
-        memory: The memory to consider (if None, the internal memory attribute #_memory is used instead).
-
-        # Returns
-        A render (e.g. image) or nothing (if the function handles the display directly).
         """
         if memory is None:
             memory = self._memory

--- a/tests/solvers/python/conftest.py
+++ b/tests/solvers/python/conftest.py
@@ -169,12 +169,12 @@ class GraphMaze(D):
         maze_memory = self._graph2mazestate(memory)
         self.maze_domain._render_from(memory=maze_memory, **kwargs)
 
-    def _get_action_mask(
+    def _get_action_mask_from(
         self, memory: Optional[D.T_memory[D.T_state]] = None
     ) -> D.T_agent[Mask]:
         # a different way to display applicable actions
-        # we could also override only _get_applicable_action() but it will be more computationally efficient to
-        # implement directly get_action_mask()
+        # we could also override only _get_applicable_action_from() but it will be more computationally efficient to
+        # implement directly _get_action_mask_from()
         if memory is None:
             memory = self._memory
         mazestate_memory = self._graph2mazestate(memory)
@@ -196,7 +196,7 @@ class GraphMaze(D):
                 action
                 for action, mask in zip(
                     self._get_action_space().get_elements(),
-                    self._get_action_mask(memory=memory),
+                    self._get_action_mask_from(memory=memory),
                 )
                 if mask
             ]
@@ -278,7 +278,7 @@ class GraphJspDomain(D):
             action_mask = action_mask[self._kept_nodes]
         return ListSpace(np.nonzero(action_mask)[0])
 
-    def _get_action_mask(
+    def _get_action_mask_from(
         self, memory: Optional[D.T_memory[D.T_state]] = None
     ) -> D.T_agent[Mask]:
         """Compute action mask.
@@ -292,7 +292,7 @@ class GraphJspDomain(D):
             action_mask = action_mask[self._kept_nodes]
             return np.asarray(action_mask, dtype=np.int8)
         else:
-            return super()._get_action_mask(memory)
+            return super()._get_action_mask_from(memory)
 
     def _get_observation_space_(self) -> Space[D.T_observation]:
         if self._gym_env.normalize_observation_space:


### PR DESCRIPTION
The library has the convention that the public methods are autocastable and have private counterparts (with leading "_") that are to be overriden by the user.
But sometimes these counterparts had important code not to be lightly override.

For instance:
- domain.reset() is autocastable and calls _reset()
- domain._reset() code is setting domain._memory, calling _state_reset(), and getting the corresponding observation
- domain._state_reset() is the method actually to be overriden by the user (not implemented by default at the higher level `Initializable`.

To simplify,
- the boilerplate code is now put directly in domain.reset()
- domain._reset() is removed to avoid confusion
- domain.state_reset() stands to be implemented

An advanced user can still override domain.reset() by being careful to manage domain._memory and use @autocastable decorator.

We do the same for
- _step
- _sample
- _get_enabled_events
- _is_enabled_event
- _get_applicable_actions
- _render