### PR TITLE
Simplify llg encoding for plado domains

### DIFF
--- a/skdecide/hub/solver/stable_baselines/autoregressive/ppo/autoregressive_ppo.py
+++ b/skdecide/hub/solver/stable_baselines/autoregressive/ppo/autoregressive_ppo.py
@@ -95,9 +95,21 @@ class AutoregressiveGraphPPO(
                     "policy_kwargs" not in data
                     or "n_graph2node_components" not in data["policy_kwargs"]
                 ):
+                    default_n_graph2node_components_kwargs = dict(
+                        action_space=data["action_space"]
+                    )
+                    if issubclass(
+                        data["policy_class"],
+                        AutoregressiveHeteroGraph2NodeActorCriticPolicy,
+                    ):
+                        default_n_graph2node_components_kwargs[
+                            "action_components_node_flag_indices"
+                        ] = data["policy_kwargs"]["action_components_node_flag_indices"]
                     n_graph2node_components = data[
                         "policy_class"
-                    ].default_n_graph2node_components(data["action_space"])
+                    ].default_n_graph2node_components(
+                        **default_n_graph2node_components_kwargs
+                    )
                 else:
                     n_graph2node_components = data["policy_kwargs"][
                         "n_graph2node_components"

--- a/tests/solvers/python/autoregressive/test_autoregressive_sb3.py
+++ b/tests/solvers/python/autoregressive/test_autoregressive_sb3.py
@@ -303,7 +303,6 @@ def test_autoregressive_heterograph2node_ppo(
         n_steps=100,
         policy_kwargs=dict(
             action_components_node_flag_indices=action_components_node_flag_indices,
-            n_graph2node_components=1,
         ),
     ) as solver:
         # pre-init algo (done normally during solve()) to extract init weights
@@ -398,7 +397,6 @@ def test_autoregressive_heterograph2node_ppo_save_load(
             n_steps=10,
             policy_kwargs=dict(
                 action_components_node_flag_indices=action_components_node_flag_indices,
-                n_graph2node_components=1,
             ),
         ) as solver:
             # solve
@@ -447,7 +445,6 @@ def test_autoregressive_heterograph2node_ppo_save_load(
             n_steps=15,
             policy_kwargs=dict(
                 action_components_node_flag_indices=action_components_node_flag_indices,
-                n_graph2node_components=1,
             ),
         ) as solver:
             # load
@@ -485,7 +482,6 @@ def test_autoregressive_heterograph2node_ppo_save_load_nok(
             n_steps=10,
             policy_kwargs=dict(
                 action_components_node_flag_indices=action_components_node_flag_indices,
-                n_graph2node_components=1,
             ),
         ) as solver:
             # solve
@@ -503,7 +499,6 @@ def test_autoregressive_heterograph2node_ppo_save_load_nok(
             n_steps=15,
             policy_kwargs=dict(
                 action_components_node_flag_indices=action_components_node_flag_indices,
-                n_graph2node_components=1,
             ),
         ) as solver:
             # load nok


### PR DESCRIPTION
As we are not trying to be domain independent, it may be sufficient to encode only the goal and state and drop the actions encoding from the graph. This allow to drastically diminish the graph size.

e.g. for an example with blocksworld 3 blocks the initial state goes from

  nodes ~ (113, 20), edges ~ (346, 4)

to

  nodes ~ (40, 7), edges ~ (136, 1)

and even, when dropping static facts, to

  nodes ~ (23, 6), edges ~ (76, 1)

(nb of nodes/edges, nb of node features/edge features)

More precisely we introduce several options to LLgEncoder:
- encode_actions: boolean deciding to include the subgraph corresponding to actions or not (now False by default)
- simplify_encoding: drop node/edge features not needed by the domain. Once the initial graph encoded we drop the node feature that are not used except the ones that could be useful by the state itself.
- encode_static_facts: include or not static predicates (can be dropped if problem independance not necessary, or if not needed to distinguish between problem as for domain blocksworld)

And we add an option for PladoDomain:
- llg_encoder_kwargs: dict allowing to specify these new options

To adapt the sb3 autoregressive gnn ppo, we update the default `n_graph2node_components` so that the dependent components starts with the first one not having a None in `action_components_node_flag_indices`.