### PR TITLE
Add missing flax installation for pytests on linux and windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ jax = [
     { version = ">=0.4", platform = "darwin", optional = true },
     { version = ">=0.4, <0.6", platform = "win32", optional = true },
 ]
-flax = { version = ">=0.12.0", python = ">=3.12", optional = true }
+flax = [
+    { version = ">=0.12.0", platform="linux", python = ">=3.12", optional = true },
+    { version = "<0.10.7", platform="win32", python = ">=3.12", optional = true },
+]
 discrete-optimization = { version = ">=0.5.0" }
 openap = { version = ">=1.5", python = ">=3.9", optional = true }
 pygeodesy = { version = ">=23.6.12", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ jax = [
     { version = ">=0.4", platform = "darwin", optional = true },
     { version = ">=0.4, <0.6", platform = "win32", optional = true },
 ]
+flax = { version = ">=0.12.0", python = ">=3.12", optional = true }
 discrete-optimization = { version = ">=0.5.0" }
 openap = { version = ">=1.5", python = ">=3.9", optional = true }
 pygeodesy = { version = ">=23.6.12", optional = true }
@@ -90,8 +91,8 @@ pyRDDLGym-rl = [
 pyRDDLGym-jax = { version = ">=2.5", python = "<3.13", optional = true }
 pyRDDLGym-gurobi = { version = ">=0.2", python = "<3.13", optional = true }
 rddlrepository = {version = ">=2.1", optional = true }
-torch-geometric = {version = ">=2.5", optional = true}
-plado = {version = ">=0.1.3", python = ">=3.10", optional = true}
+torch-geometric = { version = ">=2.5", optional = true }
+plado = { version = ">=0.1.3", python = ">=3.10", optional = true }
 torch = [
     { version = ">=2.3", optional = true, markers = "sys_platform != 'darwin' or platform_machine != 'x86_64'" },
     { version = ">=2.2", optional = true, markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'" }
@@ -155,6 +156,7 @@ all = [
     "rddlrepository",
     "pyRDDLGym-jax",
     "jax",
+    "flax",
     "pyRDDLGym-gurobi",
     "torch-geometric",
     "plado",


### PR DESCRIPTION
flax needs to be installed on linux and windows for the UP solver pytests to work with python >= 3.12