### PR TITLE
Add option --import-mode=importlib to pytest command line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ default-groups = "all"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q"
+addopts = "-ra -q --import-mode=importlib"
 testpaths = ["tests"]
 
 [build-system]


### PR DESCRIPTION
This is considered as good practice:
https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#tests-outside-application-code