### PR TITLE
Replace use of functools.cache/lru_cache by wrapt.lru_cache on methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pynng>=0.6.2",
     "pathos>=0.2.7",
     "discrete-optimization>=0.9.0",
+    "wrapt>=2.2.1",
 ]
 
 [project.urls]

--- a/src/skdecide/builders/domain/constraints.py
+++ b/src/skdecide/builders/domain/constraints.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import functools
+import wrapt
 
 from skdecide.core import Constraint, D, autocastable
 
@@ -33,7 +33,7 @@ class Constrained:
         """
         return self._get_constraints()
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _get_constraints(
         self,
     ) -> list[
@@ -72,3 +72,16 @@ class Constrained:
         The list of constraints.
         """
         raise NotImplementedError
+
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }

--- a/src/skdecide/builders/domain/dynamics.py
+++ b/src/skdecide/builders/domain/dynamics.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
-import functools
 from typing import Optional
+
+import wrapt
 
 from skdecide.core import (
     D,
@@ -352,7 +353,7 @@ class UncertainTransitions(Simulation):
         """
         return self._is_transition_value_dependent_on_next_state()
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _is_transition_value_dependent_on_next_state(self) -> bool:
         """Indicate whether _get_transition_value() requires the next_state parameter for its computation (cached).
 
@@ -407,6 +408,19 @@ class UncertainTransitions(Simulation):
         True if the state is terminal (False otherwise).
         """
         raise NotImplementedError
+
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
 
 
 class EnumerableTransitions(UncertainTransitions):

--- a/src/skdecide/builders/domain/events.py
+++ b/src/skdecide/builders/domain/events.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-import functools
 from typing import Optional, Union
 
 import numpy as np
+import wrapt
 
 from skdecide.core import D, EmptySpace, Mask, Space, autocastable
 
@@ -114,7 +114,7 @@ class Events:
         """
         return self._get_action_space()
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _get_action_space(self) -> D.T_agent[Space[D.T_event]]:
         """Get the (cached) domain action space (finite or infinite set).
 
@@ -331,6 +331,19 @@ class Events:
                 )
                 for agent, agent_applicable_actions in applicable_actions.items()
             }
+
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
 
 
 class Actions(Events):

--- a/src/skdecide/builders/domain/goals.py
+++ b/src/skdecide/builders/domain/goals.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
-import functools
 from typing import Union
+
+import wrapt
 
 from skdecide.core import D, Space, autocastable
 
@@ -33,7 +34,7 @@ class Goals:
         """
         return self._get_goals()
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _get_goals(self) -> D.T_agent[Space[D.T_observation]]:
         """Get the (cached) domain goals space (finite or infinite set).
 
@@ -104,3 +105,16 @@ class Goals:
             return goals.contains(observation)
         else:  # StrDict
             return {k: goals[k].contains(v) for k, v in observation.items()}
+
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }

--- a/src/skdecide/builders/domain/initialization.py
+++ b/src/skdecide/builders/domain/initialization.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-import functools
+import wrapt
 
 from skdecide.core import D, Distribution, SingleValueDistribution, autocastable
 
@@ -64,7 +64,7 @@ class UncertainInitialized(Initializable):
         """
         return self._get_initial_state_distribution()
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _get_initial_state_distribution(self) -> Distribution[D.T_state]:
         """Get the (cached) probability distribution of initial states.
 
@@ -92,6 +92,19 @@ class UncertainInitialized(Initializable):
         """
         raise NotImplementedError
 
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
+
 
 class DeterministicInitialized(UncertainInitialized):
     """A domain must inherit this class if it has a deterministic initial state known as white-box."""
@@ -112,7 +125,7 @@ class DeterministicInitialized(UncertainInitialized):
         """
         return self._get_initial_state()
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _get_initial_state(self) -> D.T_state:
         """Get the (cached) initial state.
 

--- a/src/skdecide/builders/domain/memory.py
+++ b/src/skdecide/builders/domain/memory.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
-import functools
 from typing import Optional, Union
+
+import wrapt
 
 from skdecide.core import D, Memory
 
@@ -55,7 +56,7 @@ class FiniteHistory(History):
 
     T_memory = Memory
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _get_memory_maxlen(self) -> int:
         """Get the (cached) memory max length.
 
@@ -82,6 +83,19 @@ class FiniteHistory(History):
         The memory max length.
         """
         raise NotImplementedError
+
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
 
 
 class Markovian(FiniteHistory):

--- a/src/skdecide/builders/domain/observability.py
+++ b/src/skdecide/builders/domain/observability.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
-import functools
 from typing import Optional, Union
+
+import wrapt
 
 from skdecide.core import D, Distribution, SingleValueDistribution, Space, autocastable
 
@@ -33,7 +34,7 @@ class PartiallyObservable:
         """
         return self._get_observation_space()
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def _get_observation_space(self) -> D.T_agent[Space[D.T_observation]]:
         """Get the (cached) observation space (finite or infinite set).
 
@@ -136,6 +137,19 @@ class PartiallyObservable:
         The probability distribution of the observation.
         """
         raise NotImplementedError
+
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
 
 
 class TransformedObservable(PartiallyObservable):

--- a/src/skdecide/core.py
+++ b/src/skdecide/core.py
@@ -16,6 +16,7 @@ from typing import Generic, Optional, TypeVar, Union, overload
 
 import numpy as np
 import numpy.typing as npt
+import wrapt
 
 __all__ = [
     "T",
@@ -512,7 +513,7 @@ class Constraint(Generic[D.T_memory, D.T_event, D.T_state], Castable):
         """
         raise NotImplementedError
 
-    @functools.lru_cache()
+    @wrapt.lru_cache()
     def is_constraint_dependent_on_next_state(self) -> bool:
         """Indicate whether this constraint requires the next_state parameter for its computation (cached).
 
@@ -539,6 +540,19 @@ class Constraint(Generic[D.T_memory, D.T_event, D.T_state], Castable):
         True if the constraint computation depends on next_state (False otherwise).
         """
         raise NotImplementedError
+
+    def __getstate__(self):
+        """Get state for pickle.
+
+        Solve issue when instance has cached methods called. (And thus unpickable cache created.)
+        See https://github.com/GrahamDumpleton/wrapt/issues/343
+
+        """
+        return {
+            key: value
+            for key, value in super().__getstate__().items()
+            if not key.startswith("_lru_cache_")
+        }
 
 
 class ImplicitConstraint(Constraint[D.T_memory, D.T_event, D.T_state]):

--- a/uv.lock
+++ b/uv.lock
@@ -6418,6 +6418,7 @@ dependencies = [
     { name = "discrete-optimization" },
     { name = "pathos" },
     { name = "pynng" },
+    { name = "wrapt" },
 ]
 
 [package.optional-dependencies]
@@ -6588,6 +6589,7 @@ requires-dist = [
     { name = "up-fast-downward", marker = "extra == 'solvers'", specifier = ">=0.4.1" },
     { name = "up-pyperplan", marker = "extra == 'solvers'", specifier = ">=1.1.0" },
     { name = "up-tamer", marker = "python_full_version < '3.12' and platform_machine == 'x86_64' and extra == 'solvers'", specifier = ">=1.1.2" },
+    { name = "wrapt", specifier = ">=2.2.1" },
     { name = "z3-solver", marker = "extra == 'pddl'" },
 ]
 provides-extras = ["shared", "domains", "solvers", "pddl", "all"]


### PR DESCRIPTION
It avoids some pitfalls. See more about it here:
- https://wrapt.readthedocs.io/en/master/bundled.html#lru-cache
- https://docs.python.org/3/library/functools.html#functools.lru_cache
- https://docs.python.org/3/faq/programming.html#faq-cache-method-calls
- https://github.com/python/cpython/issues/102618

For classes with such cached methods, we also override `__getstate__()` to let them be pickable according to
https://github.com/GrahamDumpleton/wrapt/issues/343.